### PR TITLE
Documentation automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: Create Updated Documentation PR
         run: |
+          git fetch origin
           git checkout -b "documentation-${{ github.sha }}"
           git merge origin/master --no-edit
           yarn generate-docs


### PR DESCRIPTION
Guess we do need a fetch, else it doesn't know what origin/master means. 
This is tricky since the remote git environment is not the same as locally!
The last run failed with `merge: origin/master - not something we can merge` which just means it didn't know what `origin/master` is because I haven't fetched.