### PR TITLE
Add template local.properties file for the example app

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,6 +1,7 @@
-## This file must *NOT* be checked into Version Control Systems,
-## as it contains information specific to your local configuration
+## Changes in this file must *NOT* be tracked by Version Control Systems,
+# as it contains information specific to your local configuration.
+# Only the base template should be checked in to VCS.
 
-## Uncomment for local SDK development so that gradle can locate the
-## correct RN version outside the context of an application
+## Uncomment for local SDK development, so that gradle can locate the
+# correct RN version outside the context of an application
 #reactNativeAndroidVersion=0.73.1

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -70,6 +70,12 @@ def enableProguardInReleaseBuilds = false
 def jscFlavor = 'org.webkit:android-jsc:+'
 
 android {
+    def localProperties = new Properties()
+    if (rootProject.file("local.properties").canRead()) {
+        localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+    }
+    def apiKey = localProperties['publicApiKey'] ?: publicApiKey
+
     ndkVersion rootProject.ext.ndkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
@@ -93,6 +99,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            buildConfigField "String", "PUBLIC_API_KEY", "\"${apiKey}\""
         }
         release {
             // Caution! In production, you need to generate your own keystore file.
@@ -100,6 +107,7 @@ android {
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            buildConfigField "String", "PUBLIC_API_KEY", "\"${apiKey}\""
         }
     }
 }

--- a/example/android/app/src/main/java/com/klaviyoreactnativesdkexample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/klaviyoreactnativesdkexample/MainApplication.kt
@@ -36,7 +36,7 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     SoLoader.init(this, false)
-    Klaviyo.initialize("YOUR_PUBLIC_API_KEY", this)
+    Klaviyo.initialize(BuildConfig.PUBLIC_API_KEY, this)
     registerActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
 
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -39,3 +39,7 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+# Public API Key for your Company
+# or override this from an untracked local.properties file
+publicApiKey=YOUR_PUBLIC_API_KEY

--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,0 +1,5 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration,
+# such as your Klaviyo company ID aka "Public API Key".
+
+#publicApiKey=YOUR_PUBLIC_API_KEY

--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,5 +1,6 @@
-## This file must *NOT* be checked into Version Control Systems,
+## Changes in this file must *NOT* be tracked by Version Control Systems,
 # as it contains information specific to your local configuration,
 # such as your Klaviyo company ID aka "Public API Key".
+# Only the base template should be checked in to VCS.
 
 #publicApiKey=YOUR_PUBLIC_API_KEY


### PR DESCRIPTION
# Description

A nice way to set company ID from local properties for android. This is minor because it only applies to the example app. 

As I write this I realize it'd be nice to do it for iOS example too, though not sure how. 

# Check List

- [x] Are you changing anything with the public API? NO
- [x] Are your changes backwards compatible with previous SDK Versions? YES

## Changelog / Code Overview

<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

## Test Plan

<!-- How was this code tested / How should reviewers test it? -->

## Related Issues/Tickets

<!-- Link to relevant issues or discussion -->
