### PR TITLE
Android kotlin version and min SDK fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["KlaviyoReactNativeSdk_kotlinVersion"]
-  def kotlinVersion = kotlin_version
 
   repositories {
     google()
@@ -113,7 +112,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   api "com.github.klaviyo.klaviyo-android-sdk:analytics:2.0.0"
   api "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.0.0"
-  implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.21"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,15 +103,33 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
+def localProperties = new Properties()
+if (rootProject.file("local.properties").canRead()) {
+    localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+}
+def reactNativeVersion = localProperties['reactNativeAndroidVersion'] ?: ""
+
 
 dependencies {
-  // For < 0.71, this will be from the local maven repo
-  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-  //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-native:+"
+  if (reactNativeVersion) {
+    // For local development of the SDK code, specify the react-android version to use
+    // So that the SDK can be built and .kt files are linted against a real version of react-native
+    implementation "com.facebook.react:react-android:$reactNativeVersion"
+  } else {
+    // Production build / once embedded in a react-native app,
+    // the react-native version gets loaded in from the application dependencies.
+    // For < 0.71, this will be from the local maven repo
+    // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"
+  }
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // Klaviyo Android SDK
   api "com.github.klaviyo.klaviyo-android-sdk:analytics:2.0.0"
   api "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.0.0"
+
+  // We used reflection to enumerate keywords in the Klaviyo Android SDK dynamically
   implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.21"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,7 +109,7 @@ dependencies {
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-android:0.73.1"
+  implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   api "com.github.klaviyo.klaviyo-android-sdk:analytics:2.0.0"
   api "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.0.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["KlaviyoReactNativeSdk_kotlinVersion"]
+  def kotlinVersion = kotlin_version
 
   repositories {
     google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["KlaviyoReactNativeSdk_kotlinVersion"]
+  def kotlinVersion = kotlin_version
 
   repositories {
     google()
@@ -112,6 +113,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   api "com.github.klaviyo.klaviyo-android-sdk:analytics:2.0.0"
   api "com.github.klaviyo.klaviyo-android-sdk:push-fcm:2.0.0"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.21"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["KlaviyoReactNativeSdk_kotlinVersion"]
-  def kotlinVersion = kotlin_version
 
   repositories {
     google()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
 KlaviyoReactNativeSdk_compileSdkVersion=31
-KlaviyoReactNativeSdk_kotlinVersion=1.7.0
+KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_ndkversion=21.4.7075529
 KlaviyoReactNativeSdk_targetSdkVersion=31

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,0 +1,6 @@
+## This file must *NOT* be checked into Version Control Systems,
+## as it contains information specific to your local configuration
+
+## Uncomment for local SDK development so that gradle can locate the
+## correct RN version outside the context of an application
+#reactNativeAndroidVersion=0.73.1

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -49,7 +49,7 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
     override fun setProfile(profile: ReadableMap) {
       val parsedProfile = Profile()
 
-      profile.toHashMap().forEach { (key, value) ->
+      profile.toHashMap().iterator().forEach { (key, value) ->
         when (key) {
           LOCATION, PROPERTIES ->
             (value as? HashMap<*, *>)?.forEach { (key, value) ->

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -38,11 +38,7 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
     }
 
     private inline fun <reified T> extractConstants(): Map<String, String> where T : Keyword {
-      return T::class.nestedClasses.filter {
-        it.visibility == KVisibility.PUBLIC && it.objectInstance != null
-      }.associate {
-        it.simpleName.toString() to (it.objectInstance as T).name
-      }
+      return emptyMap()
     }
 
     @ReactMethod

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -38,7 +38,11 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
     }
 
     private inline fun <reified T> extractConstants(): Map<String, String> where T : Keyword {
-      return emptyMap()
+      return T::class.nestedClasses.filter {
+        it.visibility == KVisibility.PUBLIC && it.objectInstance != null
+      }.associate {
+        it.simpleName.toString() to (it.objectInstance as T).name
+      }
     }
 
     @ReactMethod


### PR DESCRIPTION
# Description
These take care of some android build issues on older RN versions.
- Specify kotlin version 1.8 for compat with android sdk
- Avoid using an android 24 API `foreach` method
- Revert react-native dependency to the template syntax, and put in a local.properties file so we can override it for development.

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

## Test Plan

<!-- How was this code tested / How should reviewers test it? -->

## Related Issues/Tickets

<!-- Link to relevant issues or discussion -->
