### PR TITLE
Bump example iOS project lockfile

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - hermes-engine (0.73.1):
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
-  - klaviyo-react-native-sdk (0.1.0):
+  - klaviyo-react-native-sdk (0.1.1):
     - glog
     - KlaviyoSwift (= 3.0.0)
     - RCT-Folly (= 2022.05.16.00)
@@ -1335,7 +1335,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
-  klaviyo-react-native-sdk: ab1e9cd0d87782ebbd45235ed71bed06c0c85ee7
+  klaviyo-react-native-sdk: 840f09e0293979354a0a44ee38c9ae0459e9e33f
   KlaviyoSwift: 772fd78ef4b1f5d22c192b19e3ac2fd58ad49c90
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c


### PR DESCRIPTION
As I understand it, the klaviyo RN sdk is installed straight from the parent directory, so this lockfile needs to stay in sync.