### PR TITLE
Remove local.properties from git index

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,7 +107,7 @@ def localProperties = new Properties()
 if (rootProject.file("local.properties").canRead()) {
     localProperties.load(new FileInputStream(rootProject.file("local.properties")))
 }
-def reactNativeVersion = localProperties['reactNativeAndroidVersion'] ?: ""
+def reactNativeAndroidVersion = localProperties['reactNativeAndroidVersion'] ?: ""
 
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,10 +111,10 @@ def reactNativeVersion = localProperties['reactNativeAndroidVersion'] ?: ""
 
 
 dependencies {
-  if (reactNativeVersion) {
+  if (reactNativeAndroidVersion) {
     // For local development of the SDK code, specify the react-android version to use
     // So that the SDK can be built and .kt files are linted against a real version of react-native
-    implementation "com.facebook.react:react-android:$reactNativeVersion"
+    implementation "com.facebook.react:react-android:$reactNativeAndroidVersion"
   } else {
     // Production build / once embedded in a react-native app,
     // the react-native version gets loaded in from the application dependencies.

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -1,7 +1,8 @@
 ## Changes in this file must *NOT* be tracked by Version Control Systems,
 # as it contains information specific to your local configuration.
 # Only the base template should be checked in to VCS.
+# Copy this file to `local.properties` to set your local overrides
 
-## Uncomment for local SDK development, so that gradle can locate the
+## Used for local SDK development, so that gradle can locate the
 # correct RN version outside the context of an application
-#reactNativeAndroidVersion=0.73.1
+reactNativeAndroidVersion=0.73.1

--- a/example/android/local.properties.template
+++ b/example/android/local.properties.template
@@ -2,5 +2,6 @@
 # as it contains information specific to your local configuration,
 # such as your Klaviyo company ID aka "Public API Key".
 # Only the base template should be checked in to VCS.
+# Copy this file to `local.properties` to set your local overrides
 
-#publicApiKey=YOUR_PUBLIC_API_KEY
+publicApiKey=YOUR_PUBLIC_API_KEY


### PR DESCRIPTION
I mistakenly thought you could have an initial template of a file, and then gitignore it so that changes are ignored. I guess not, and you have to put in a template file like this instead.
This PR renames the two `local.properties` to `local.properties.template` and adds instructions to copy/rename the file so that local config is indeed untracked.
