### PR TITLE
Bridge initialize and setPushToken to RN layer

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -50,8 +50,16 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
   override fun initialize(apiKey: String) {
     Klaviyo.initialize(apiKey, context)
 
+    // Attach the Klaviyo lifecycle callbacks to the application if initialize
+    // is invoked from the react-native layer.
     val application = context.applicationContext as? Application
-    application?.registerActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
+
+    if (application != null) {
+      application.unregisterActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
+      application.registerActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
+    } else {
+      println("KlaviyoReactNativeSdkModule: Could not register lifecycle callbacks.")
+    }
   }
 
     @ReactMethod
@@ -117,6 +125,16 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
     @ReactMethod
     override fun resetProfile() {
       Klaviyo.resetProfile()
+    }
+
+    @ReactMethod
+    override fun setPushToken(token: String) {
+      Klaviyo.setPushToken(token)
+    }
+
+    @ReactMethod
+    override fun getPushToken(callback: Callback) {
+      callback.invoke(Klaviyo.getPushToken())
     }
 
     @ReactMethod

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -1,5 +1,6 @@
 package com.klaviyoreactnativesdk
 
+import android.app.Application
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
@@ -44,6 +45,14 @@ class KlaviyoReactNativeSdkModule internal constructor(private val context: Reac
         it.simpleName.toString() to (it.objectInstance as T).name
       }
     }
+
+  @ReactMethod
+  override fun initialize(apiKey: String) {
+    Klaviyo.initialize(apiKey, context)
+
+    val application = context.applicationContext as? Application
+    application?.registerActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
+  }
 
     @ReactMethod
     override fun setProfile(profile: ReadableMap) {

--- a/android/src/oldarch/KlaviyoReactNativeSdkSpec.kt
+++ b/android/src/oldarch/KlaviyoReactNativeSdkSpec.kt
@@ -30,5 +30,9 @@ abstract class KlaviyoReactNativeSdkSpec internal constructor(context: ReactAppl
 
     abstract fun resetProfile()
 
+    abstract fun setPushToken(token: String)
+
+    abstract fun getPushToken(callback: Callback)
+
     abstract fun createEvent(event: ReadableMap)
   }

--- a/android/src/oldarch/KlaviyoReactNativeSdkSpec.kt
+++ b/android/src/oldarch/KlaviyoReactNativeSdkSpec.kt
@@ -7,6 +7,8 @@ import com.facebook.react.bridge.ReadableMap
 
 abstract class KlaviyoReactNativeSdkSpec internal constructor(context: ReactApplicationContext) :
   ReactContextBaseJavaModule(context) {
+    abstract fun initialize(apiKey: String)
+
     abstract fun setProfile(profile: ReadableMap)
 
     abstract fun setExternalId(externalId: String)

--- a/example/android/app/src/main/java/com/klaviyoreactnativesdkexample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/klaviyoreactnativesdkexample/MainApplication.kt
@@ -36,6 +36,8 @@ class MainApplication : Application(), ReactApplication {
   override fun onCreate() {
     super.onCreate()
     SoLoader.init(this, false)
+
+    // If initializing from the native layer:
     Klaviyo.initialize(BuildConfig.PUBLIC_API_KEY, this)
     registerActivityLifecycleCallbacks(Klaviyo.lifecycleCallbacks)
 

--- a/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
+++ b/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
@@ -11,6 +11,7 @@
   // They will be passed down to the ViewController used by React Native.
   self.initialProps = @{};
 
+  // If initializing from Native layer
   [PushNotificationsHelper initializeSDK];
   [PushNotificationsHelper requestPushPermission];
 

--- a/example/src/AppViewInterface.ts
+++ b/example/src/AppViewInterface.ts
@@ -4,6 +4,7 @@ import {
   getExternalId,
   getPhoneNumber,
   resetProfile,
+  setPushToken,
   sendRandomEvent,
   setEmail,
   setExternalId,
@@ -53,6 +54,11 @@ export const appViews: AppViewInterface[] = [
     title: 'Click to RESET the full profile',
     color: '#ffcccb',
     onPress: resetProfile,
+  },
+  {
+    title: 'Click to set a FAKE push token',
+    color: '#ffcccb',
+    onPress: setPushToken,
   },
   {
     title: 'Click to get current email',

--- a/example/src/AppViewInterface.ts
+++ b/example/src/AppViewInterface.ts
@@ -1,4 +1,5 @@
 import {
+  initialize,
   getEmail,
   getExternalId,
   getPhoneNumber,
@@ -18,6 +19,11 @@ export interface AppViewInterface {
 }
 
 export const appViews: AppViewInterface[] = [
+  {
+    title: 'Click to initialize',
+    color: '#841584',
+    onPress: initialize,
+  },
   {
     title: 'Click to set the full profile',
     color: '#841584',

--- a/example/src/KlaviyoReactWrapper.ts
+++ b/example/src/KlaviyoReactWrapper.ts
@@ -85,6 +85,14 @@ export const resetProfile = async () => {
   }
 };
 
+export const setPushToken = async () => {
+  try {
+    Klaviyo.setPushToken('FAKE_PUSH_TOKEN');
+  } catch (e: any) {
+    console.log(e.message, e.code);
+  }
+};
+
 export const setProfileAttribute = async () => {
   try {
     Klaviyo.setProfileAttribute('CUSTOM', generateRandomName(12));

--- a/example/src/KlaviyoReactWrapper.ts
+++ b/example/src/KlaviyoReactWrapper.ts
@@ -14,6 +14,15 @@ import {
   getRandomMetric,
 } from './RandomGenerators';
 
+export const initialize = async () => {
+  try {
+    // If initializing from RN Layer: (replace with your public key)
+    Klaviyo.initialize('YOUR_PUBLIC_API_KEY');
+  } catch (e: any) {
+    console.log(e.message, e.code);
+  }
+};
+
 export const setEmail = async () => {
   try {
     Klaviyo.setEmail(generateRandomEmails());

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -43,6 +43,11 @@ public class KlaviyoBridge: NSObject {
   }
 
   @objc
+  public static func initialize(_ apiKey: String) {
+      KlaviyoSDK().initialize(with: apiKey)
+  }
+
+  @objc
   public static func setProfile(
       _ profileDict: [String: AnyObject]
   ) {

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -113,6 +113,11 @@ public class KlaviyoBridge: NSObject {
   }
 
   @objc
+  public static func setPushToken(_ value: String) {
+    KlaviyoSDK().set(pushToken: value)
+  }
+
+  @objc
   public static func resetProfile() {
     KlaviyoSDK().resetProfile()
   }

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -17,6 +17,11 @@ RCT_EXPORT_MODULE()
     };
 }
 
+RCT_EXPORT_METHOD(initialize: (NSString *)apiKey)
+{
+    [KlaviyoBridge initialize: apiKey];
+}
+
 //MARK: Setters
 
 RCT_EXPORT_METHOD(setProfile: (NSDictionary *)profileDict)

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -22,8 +22,6 @@ RCT_EXPORT_METHOD(initialize: (NSString *)apiKey)
     [KlaviyoBridge initialize: apiKey];
 }
 
-//MARK: Setters
-
 RCT_EXPORT_METHOD(setProfile: (NSDictionary *)profileDict)
 {
     [KlaviyoBridge setProfile:profileDict];
@@ -57,6 +55,11 @@ RCT_EXPORT_METHOD(setPhoneNumber: (NSString *)phoneNumber)
 RCT_EXPORT_METHOD(getPhoneNumber: (RCTResponseSenderBlock)callback) {
     NSString *phoneNumber = [KlaviyoBridge getPhoneNumber];
     callback(@[phoneNumber]);
+}
+
+RCT_EXPORT_METHOD(setPushToken: (NSString *)pushToken)
+{
+    [KlaviyoBridge setPushToken: pushToken];
 }
 
 RCT_EXPORT_METHOD(resetProfile)

--- a/src/NativeKlaviyoReactNativeSdk.ts
+++ b/src/NativeKlaviyoReactNativeSdk.ts
@@ -2,6 +2,7 @@ import { TurboModuleRegistry } from 'react-native';
 import type { TurboModule } from 'react-native';
 import type { KlaviyoEventAPI } from './Event';
 import type { KlaviyoProfileApi } from './Profile';
+import type { KlaviyoPushApi } from './Push';
 
 /**
  * The Klaviyo React Native SDK Interface
@@ -9,7 +10,10 @@ import type { KlaviyoProfileApi } from './Profile';
  * This interface extends the KlaviyoEventAPI and KlaviyoProfileApi interfaces,
  * providing a unified API for interacting with Klaviyo's event tracking and profile management features.
  */
-export interface KlaviyoInterface extends KlaviyoEventAPI, KlaviyoProfileApi {
+export interface KlaviyoInterface
+  extends KlaviyoEventAPI,
+    KlaviyoProfileApi,
+    KlaviyoPushApi {
   /**
    * Initializes the Klaviyo SDK with the given API key.
    *

--- a/src/NativeKlaviyoReactNativeSdk.ts
+++ b/src/NativeKlaviyoReactNativeSdk.ts
@@ -9,7 +9,14 @@ import type { KlaviyoProfileApi } from './Profile';
  * This interface extends the KlaviyoEventAPI and KlaviyoProfileApi interfaces,
  * providing a unified API for interacting with Klaviyo's event tracking and profile management features.
  */
-export interface KlaviyoInterface extends KlaviyoEventAPI, KlaviyoProfileApi {}
+export interface KlaviyoInterface extends KlaviyoEventAPI, KlaviyoProfileApi {
+  /**
+   * Initializes the Klaviyo SDK with the given API key.
+   *
+   * @param apiKey Your public API key
+   */
+  initialize(apiKey: string): void;
+}
 
 export interface Spec extends TurboModule, KlaviyoInterface {}
 

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -1,0 +1,18 @@
+/**
+ * Interface for the Klaviyo Push API
+ */
+export interface KlaviyoPushApi {
+  /**
+   * Set the push token for the current profile
+   *
+   * @param token
+   */
+  setPushToken(token: String): void;
+
+  /**
+   * Get the push token for the current profile from the SDK
+   *
+   * @param callback
+   */
+  getPushToken(callback: Function | undefined): String | null;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,6 +41,12 @@ export const Klaviyo: Spec = {
   resetProfile(): void {
     KlaviyoReactNativeSdk.resetProfile();
   },
+  setPushToken(token: String) {
+    KlaviyoReactNativeSdk.setPushToken(token);
+  },
+  getPushToken(callback: Function | undefined): String | null {
+    return KlaviyoReactNativeSdk.getPushToken(callback);
+  },
   createEvent(event: Event): void {
     KlaviyoReactNativeSdk.createEvent(event);
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,9 @@ import type { Event } from './Event';
  * Implementation of the {@link KlaviyoInterface}
  */
 export const Klaviyo: Spec = {
+  initialize(apiKey: String): void {
+    KlaviyoReactNativeSdk.initialize(apiKey);
+  },
   setProfile(profile: Profile): void {
     KlaviyoReactNativeSdk.setProfile(formatProfile(profile));
   },


### PR DESCRIPTION
# Description
Adds initialize and setPushToken methods to the RN Klaviyo SDK.

# Check List

- [x] Are you changing anything with the public API? `YES`
- [x] Are your changes backwards compatible with previous SDK Versions? `SORT OF`

## Changelog / Code Overview
- Added initialize and setPushToken to the react Klaviyo public API
- For android, handle lifecycle listeners and application context from this SDK's 
- Bridged the two methods from the native layer
- Added very rudimentary usage to the example app for each

## Test Plan
- [ ] TODO update the test/example apps to use these methods.

## Related Issues/Tickets
- Will be updating android dependency to use [this](https://github.com/klaviyo/klaviyo-android-sdk/pull/129)
