### PR TITLE
Bump to Klaviyo Native SDK Dependencies: Android=2.1.1 Swift=3.0.4 | RN SDK = 0.3.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.1.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.1.1
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -16,9 +16,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
   - klaviyo-react-native-sdk (0.2.1):
-    - KlaviyoSwift (= 3.0.3)
+    - KlaviyoSwift (= 3.0.4)
     - React-Core
-  - KlaviyoSwift (3.0.3):
+  - KlaviyoSwift (3.0.4):
     - AnyCodable-FlightSchool
   - libevent (2.1.12)
   - RCT-Folly (2022.05.16.00):
@@ -1234,8 +1234,8 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
-  klaviyo-react-native-sdk: 54616135f434ad3569debf926e2b0c00704f26e9
-  KlaviyoSwift: 9318efaa92f5435d63aa093e3e9d49af947b7685
+  klaviyo-react-native-sdk: 1c007b5f9647c0d1c239c2457b2e286dd6d3b855
+  KlaviyoSwift: 47540deeab5070db86346bf1fdcb9b8e4c5e0c09
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 6dda55e483f75d2b43781d8ad5bd7df276a50981

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - hermes-engine (0.73.1):
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
-  - klaviyo-react-native-sdk (0.2.1):
+  - klaviyo-react-native-sdk (0.3.0):
     - KlaviyoSwift (= 3.0.4)
     - React-Core
   - KlaviyoSwift (3.0.4):
@@ -1234,7 +1234,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
-  klaviyo-react-native-sdk: 1c007b5f9647c0d1c239c2457b2e286dd6d3b855
+  klaviyo-react-native-sdk: 7a74ce591e556acc913f58d39f6c6a51b02d2eca
   KlaviyoSwift: 47540deeab5070db86346bf1fdcb9b8e4c5e0c09
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk-example",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "3.0.3"
+  s.dependency "KlaviyoSwift", "3.0.4"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Official Klaviyo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Description
This fixes a bug with notification display on android. Previously, it was required to initialize the SDK prior to displaying a notification (receiving the FCM message intent). If the developer was initializing from react native code only, then initialize did not happen in time, which prevented notification from displaying. This would only happen if the application was in a terminal state.
This android version bump included a fix to remove notification display's dependency upon `initialize`.

# Check List

- [x] Are you changing anything with the public API?
  - NO
- [x] Are your changes backwards compatible with previous SDK Versions?
  - YES

## Changelog / Code Overview
- Bump to Klaviyo Android version 2.1.1

## Test Plan
- With test app, kill the app and reboot your device. 
- Send a notification from klaviyo
- Notification should pop up (previously, it wouldn't appear, and you could see an error in the logcat)

## Related Issues/Tickets
- Has not been reported
- CHNL-6476
