### PR TITLE
Adopt Android SDK version 2.2.1

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.1.1
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.2.0
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.2.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.2.1
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '1.14.3'
+gem 'cocoapods', '1.15.2'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,7 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -15,11 +17,12 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.2.0)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -34,7 +37,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -71,6 +74,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.2.0)
     public_suffix (4.0.7)
     rexml (3.2.6)
     ruby-macho (2.5.1)
@@ -92,7 +96,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.3, < 7.1.0)
-  cocoapods (= 1.14.3)
+  cocoapods (= 1.15.2)
 
 RUBY VERSION
    ruby 2.6.10p210

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - hermes-engine (0.73.1):
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
-  - klaviyo-react-native-sdk (0.3.0):
+  - klaviyo-react-native-sdk (0.3.1):
     - KlaviyoSwift (= 3.0.4)
     - React-Core
   - KlaviyoSwift (3.0.4):
@@ -1234,7 +1234,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
-  klaviyo-react-native-sdk: 7a74ce591e556acc913f58d39f6c6a51b02d2eca
+  klaviyo-react-native-sdk: 878dada99cf8a2e39542d938831d3c8b11d5d9de
   KlaviyoSwift: 47540deeab5070db86346bf1fdcb9b8e4c5e0c09
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
@@ -1279,7 +1279,7 @@ SPEC CHECKSUMS:
   React-utils: fefa27e6d4a5b733f5e76cf8802ccf023ff8cc94
   ReactCommon: 73242ec9768e71688f35ad97ae3d0709a0f66435
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
+  Yoga: 2b33a7ac96c58cdaa7b810948fc6a2a76ed2d108
 
 PODFILE CHECKSUM: 8551fc99e362b9a5d9f471b52ed693a80cd33445
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk-example",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Official Klaviyo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Description
Adopts recently released Klaviyo Android SDK version 2.2.0 and 
Increment React Native to 0.3.1

# Check List
- [x] Are you changing anything with the public API?
  - NO
- [x] Are your changes backwards compatible with previous SDK Versions?
  - YES

## Changelog / Code Overview
Version 2.2.0 of the Klaviyo Android SDK added new logic to the networking layer to reduce redundant API calls while also extending retry logic to better retain data during a period of high traffic for a particular company. 

## Test Plan
- Unit tests, integration tests and device testing have been performed on the Android SDK and internal test apps. 
- [x] Ran tests against internal React Native test apps
