### PR TITLE
Patch for profile key enums mismatching

### DIFF
--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -84,7 +84,16 @@ public class KlaviyoBridge: NSObject {
 
   @objc
   public static func setProfileAttribute(_ key: String, value: String) {
-      KlaviyoSDK().set(profileAttribute: getProfileKey(key), value: value)
+      switch key {
+      case "external_id":
+          setExternalId(value)
+      case "email":
+          setEmail(value)
+      case "phone_number":
+          setPhoneNumber(value)
+      default:
+          KlaviyoSDK().set(profileAttribute: getProfileKey(key), value: value)
+      }
   }
 
   @objc

--- a/src/Profile.ts
+++ b/src/Profile.ts
@@ -67,16 +67,19 @@ export interface KlaviyoProfileApi {
 export enum ProfileProperty {
   /**
    * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system, such as a point-of-sale system. Format varies based on the external system.
+   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
    */
   EXTERNAL_ID = PROFILE_KEYS.EXTERNAL_ID ?? 'external_id',
 
   /**
    * Individual's email address
+   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
    */
   EMAIL = PROFILE_KEYS.EMAIL ?? 'email',
 
   /**
    * Individual's phone number in E.164 format
+   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
    */
   PHONE_NUMBER = PROFILE_KEYS.PHONE_NUMBER ?? 'phone_number',
 


### PR DESCRIPTION
# Description
iOS SDK does not use enums for profile identifiers `external_id`, `email` and `phone_number` and isn't intended to consume identifiers with `setProfileAttribute`. Since RN is exposing those enums cross-platform, it is reasonable a developer could expect to set identifiers with that method. But we discovered that could lead to an iOS issue with identifiers not getting tracked in internal state when set via `setProfileAttribute`, though the identifier still makes it to the backend for that profile. 
To resolve this confusion, we're deprecating these enums on android and RN to discourage setting identifiers via the attribute setter method. In a future release we will delete them entirely, but in the mean time updated the bridging behavior to direct any identifiers set with these profile keys to use the explicit setter functions.

# Check List
- [x] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?

Yes it is a change to the SDK's API, but a deprecation is backward compatible.

## Changelog / Code Overview
- Added a patch to the swift bridge file so that using `setProfileAttribute` with an identifier enum will be routed to the correct setter function (consistent with how android would behave)
- Deprecated the enums with warning, to be removed in next release. 

## Test Plan
Tested with the example app with and without this change. 

## Related Issues/Tickets
Related android PR https://github.com/klaviyo/klaviyo-android-sdk/pull/150
CHNL-7225
