### PR TITLE
Remove deprecated profile identifier keys

### DIFF
--- a/src/Profile.ts
+++ b/src/Profile.ts
@@ -66,24 +66,6 @@ export interface KlaviyoProfileApi {
  */
 export enum ProfileProperty {
   /**
-   * A unique identifier used by customers to associate Klaviyo profiles with profiles in an external system, such as a point-of-sale system. Format varies based on the external system.
-   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
-   */
-  EXTERNAL_ID = PROFILE_KEYS.EXTERNAL_ID ?? 'external_id',
-
-  /**
-   * Individual's email address
-   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
-   */
-  EMAIL = PROFILE_KEYS.EMAIL ?? 'email',
-
-  /**
-   * Individual's phone number in E.164 format
-   * @deprecated Setting identifiers via setProfileAttribute is deprecated, and this enum will be removed in an upcoming release. Use the corresponding setter function instead.
-   */
-  PHONE_NUMBER = PROFILE_KEYS.PHONE_NUMBER ?? 'phone_number',
-
-  /**
    * Individual's first name
    */
   FIRST_NAME = PROFILE_KEYS.FIRST_NAME ?? 'first_name',
@@ -281,15 +263,18 @@ export function formatProfile(
   let bridgedProfile: Record<ProfileProperty, Object> = {};
 
   if (profile.externalId) {
-    bridgedProfile[ProfileProperty.EXTERNAL_ID] = profile.externalId;
+    const key = PROFILE_KEYS.EXTERNAL_ID ?? 'external_id';
+    bridgedProfile[key] = profile.externalId;
   }
 
   if (profile.email) {
-    bridgedProfile[ProfileProperty.EMAIL] = profile.email;
+    const key = PROFILE_KEYS.EMAIL ?? 'email';
+    bridgedProfile[key] = profile.email;
   }
 
   if (profile.phoneNumber) {
-    bridgedProfile[ProfileProperty.PHONE_NUMBER] = profile.phoneNumber;
+    const key = PROFILE_KEYS.PHONE_NUMBER ?? 'phone_number';
+    bridgedProfile[key] = profile.phoneNumber;
   }
 
   if (profile.firstName) {


### PR DESCRIPTION
# Description
Following #143, remove the deprecated keys

# Check List

- [x] Are you changing anything with the public API? 
  - Yes, this should be merged for a subsequent release, after #143 has been released on its own.
- [x] Are your changes backwards compatible with previous SDK Versions?
  - No, this should get merged by or before major version 1.0.

## Changelog / Code Overview
- Remove profile keys corresponding to identifiers.

## Test Plan
Confirmed that with the deletion, you can't call `setProfileAttribute` with identifier keys, unless you go out of your way to use a custom key with a value like `"email"`. Even then, I kept the little patch in the swift bridge code from the previous PR, so that would still get routed to the explicit setter on iOS like it does on Android. 

## Related Issues/Tickets
#143 
CHNL-6998