### PR TITLE
Example app | Updated app delegate to fix initial url being null

### DIFF
--- a/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
+++ b/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
@@ -31,8 +31,11 @@ BOOL useNativeImplementation = YES;
   } else {
     // Initialize cross-platform push library, e.g. Firebase
   }
+  
+  // refer to installation step 16 below
+  NSMutableDictionary * launchOptionsWithURL = [self getLaunchOptionsWithURL:launchOptions];
 
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return [super application:application didFinishLaunchingWithOptions:launchOptionsWithURL];
 }
 
 // Installation Step 6: Implement this delegate to receive and set the push token
@@ -122,6 +125,26 @@ BOOL useNativeImplementation = YES;
 // notification.
 - (void)applicationDidBecomeActive:(UIApplication *)application {
   [PushNotificationsHelper updateBadgeCount:0];
+}
+
+
+// Installation Step 16: call this method from `application:didFinishLaunchingWithOptions:` before calling the super class method with
+// the launch arguments. This is a workaround for a react issue where if the app is terminated the deep link isn't sent to the react native layer
+// when it is coming from a remote notification.
+// https://github.com/facebook/react-native/issues/32350
+- (NSMutableDictionary *)getLaunchOptionsWithURL:(NSDictionary * _Nullable)launchOptions {
+  NSMutableDictionary *launchOptionsWithURL = [NSMutableDictionary dictionaryWithDictionary:launchOptions];
+  if (launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
+    NSDictionary *remoteNotification = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
+    
+    if (remoteNotification[@"url"]) {
+      NSString *initialURL = remoteNotification[@"url"];
+      if (!launchOptions[UIApplicationLaunchOptionsURLKey]) {
+        launchOptionsWithURL[UIApplicationLaunchOptionsURLKey] = [NSURL URLWithString:initialURL];
+      }
+    }
+  }
+  return launchOptionsWithURL;
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge


### PR DESCRIPTION
# Description

An [issue](https://github.com/klaviyo/klaviyo-react-native-sdk/issues/140) was raised by one of our developers citing that deep linking was not working when the app is terminated. On digging noticed that this is an issue with react native so added a workaround for our developers to use when they encounter this issue. Since this is not an SDK issue there is no fix at the SDK level and developers would have to add this workaround to their native iOS app. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

## Test Plan

<!-- How was this code tested / How should reviewers test it? -->

## Related Issues/Tickets

<!-- Link to relevant issues or discussion -->
