### PR TITLE
Updated occurrences of `String` to `string`

### DIFF
--- a/src/Profile.ts
+++ b/src/Profile.ts
@@ -16,44 +16,44 @@ export interface KlaviyoProfileApi {
    * Update a profile's external ID.
    * @param externalId - The external ID to set
    */
-  setExternalId(externalId: String): void;
+  setExternalId(externalId: string): void;
 
   /**
    * Retrieve a profile's external ID.
    * @param callback - The callback function to handle the response
    */
-  getExternalId(callback: Function | undefined): String | null;
+  getExternalId(callback: Function | undefined): string | null;
 
   /**
    * Update a profile's email address.
    * @param email - The email address to set
    */
-  setEmail(email: String): void;
+  setEmail(email: string): void;
 
   /**
    * Retrieve a profile's email address.
    * @param callback - The callback function to handle the response
    */
-  getEmail(callback: Function | undefined): String | null;
+  getEmail(callback: Function | undefined): string | null;
 
   /**
    * Update a profile's phone number.
    * @param phoneNumber - The phone number to set
    */
-  setPhoneNumber(phoneNumber: String): void;
+  setPhoneNumber(phoneNumber: string): void;
 
   /**
    * Retrieve a profile's phone number.
    * @param callback - The callback function to handle the response
    */
-  getPhoneNumber(callback: Function | undefined): String | null;
+  getPhoneNumber(callback: Function | undefined): string | null;
 
   /**
    * Update a profile's properties.
    * @param propertyKey - The property key to set
    * @param value - The property value to set
    */
-  setProfileAttribute(propertyKey: ProfilePropertyKey, value: String): void;
+  setProfileAttribute(propertyKey: ProfilePropertyKey, value: string): void;
 
   /**
    * Clear the current profile and set it to a new anonymous profile

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -7,12 +7,12 @@ export interface KlaviyoPushApi {
    *
    * @param token
    */
-  setPushToken(token: String): void;
+  setPushToken(token: string): void;
 
   /**
    * Get the push token for the current profile from the SDK
    *
    * @param callback
    */
-  getPushToken(callback: Function | undefined): String | null;
+  getPushToken(callback: Function | undefined): string | null;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,40 +11,40 @@ import type { Event } from './Event';
  * Implementation of the {@link KlaviyoInterface}
  */
 export const Klaviyo: Spec = {
-  initialize(apiKey: String): void {
+  initialize(apiKey: string): void {
     KlaviyoReactNativeSdk.initialize(apiKey);
   },
   setProfile(profile: Profile): void {
     KlaviyoReactNativeSdk.setProfile(formatProfile(profile));
   },
-  setExternalId(externalId: String): void {
+  setExternalId(externalId: string): void {
     KlaviyoReactNativeSdk.setExternalId(externalId);
   },
-  getExternalId(callback: Function | undefined): String | null {
+  getExternalId(callback: Function | undefined): string | null {
     return KlaviyoReactNativeSdk.getExternalId(callback);
   },
-  setEmail(email: String): void {
+  setEmail(email: string): void {
     KlaviyoReactNativeSdk.setEmail(email);
   },
-  getEmail(callback: Function | undefined): String | null {
+  getEmail(callback: Function | undefined): string | null {
     return KlaviyoReactNativeSdk.getEmail(callback);
   },
-  setPhoneNumber(phoneNumber: String): void {
+  setPhoneNumber(phoneNumber: string): void {
     KlaviyoReactNativeSdk.setPhoneNumber(phoneNumber);
   },
-  getPhoneNumber(callback: Function | undefined): String | null {
+  getPhoneNumber(callback: Function | undefined): string | null {
     return KlaviyoReactNativeSdk.getPhoneNumber(callback);
   },
-  setProfileAttribute(propertyKey: ProfilePropertyKey, value: String): void {
+  setProfileAttribute(propertyKey: ProfilePropertyKey, value: string): void {
     KlaviyoReactNativeSdk.setProfileAttribute(propertyKey, value);
   },
   resetProfile(): void {
     KlaviyoReactNativeSdk.resetProfile();
   },
-  setPushToken(token: String) {
+  setPushToken(token: string) {
     KlaviyoReactNativeSdk.setPushToken(token);
   },
-  getPushToken(callback: Function | undefined): String | null {
+  getPushToken(callback: Function | undefined): string | null {
     return KlaviyoReactNativeSdk.getPushToken(callback);
   },
   createEvent(event: Event): void {


### PR DESCRIPTION
# Description

In TypeScript, `string` is a primitive type, while `String` is a global object that is a wrapper around the primitive `string` type. We were using both of these interchangeably which could lead to issues like this - 

```
let existingEmail = Klaviyo.getEmail(undefined);
    Klaviyo.setProfile({
      email: existingEmail, //this is an error: TS2322: Type String | null is not assignable to type string | undefined
    });
```

The above error is because `getEmail` returns an instance of type `String` whereas `setProfile` accepts an instance of `Profile` whose email property is of type `string`.

The fix was to across the board using `string` instead of `String`. This in some cases could be a breaking change if developer made any provision in their code to handle this inconsistency. Since we are in beta we will release this change as a minor version update or roll it into our first major version release. 

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

## Test Plan

<!-- How was this code tested / How should reviewers test it? -->

## Related Issues/Tickets

<!-- Link to relevant issues or discussion -->
