### PR TITLE
CHNL-10057 Note react native firebase sdk capitalization issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ In order to collect the APNs push token in your React Native code you need to:
 
 For Android token collection, there isn't any additional setup required on the native side. The above code should work as is.
 
+##### iOS APNS Token Troubleshooting
+There is an open issue with [`@react-native-firebase/messaging`](https://github.com/invertase/react-native-firebase/issues/8022) where the SDK will uppercase any APNS token returned using `messaging().getAPNSToken()`.
+You can verify this by adding a log the `AppDelegate.m` file that prints the deviceToken (you will need to convert to a hex string).
+APNS Services is case-insensitive, so be sure you are not registering the same device token twice.
+
 #### Native Token Collection
 
 Follow the platform-specific instructions below:

--- a/README.md
+++ b/README.md
@@ -351,11 +351,6 @@ In order to collect the APNs push token in your React Native code you need to:
 
 For Android token collection, there isn't any additional setup required on the native side. The above code should work as is.
 
-##### iOS APNS Token Troubleshooting
-There is an open issue with [`@react-native-firebase/messaging`](https://github.com/invertase/react-native-firebase/issues/8022) where the SDK will uppercase any APNS token returned using `messaging().getAPNSToken()`.
-You can verify this by adding a log the `AppDelegate.m` file that prints the deviceToken (you will need to convert to a hex string).
-APNS Services is case-insensitive, so be sure you are not registering the same device token twice.
-
 #### Native Token Collection
 
 Follow the platform-specific instructions below:

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -54,26 +54,26 @@ there are two possible reasons for this:
 
 ### Deep links in push notifications not getting sent over to React Native layer when the iOS app is terminated
 
-When the iOS app is terminated (killed from the app switcher by swiping up), there is a bug in React Native that 
-prevents the native layer from calling the listeners set up in React Native to listen to incoming deep links. 
-The listener in question here is `Linking.getInitialURL()` which is expected to be called when a deep link is 
+When the iOS app is terminated (killed from the app switcher by swiping up), there is a bug in React Native that
+prevents the native layer from calling the listeners set up in React Native to listen to incoming deep links.
+The listener in question here is `Linking.getInitialURL()` which is expected to be called when a deep link is
 available while the app is terminated.
 
-You can find the open issue describing this problem on React Native's GitHub repository [Here](https://github.com/facebook/react-native/issues/32350). 
-There are many workarounds suggested in this issue's thread and a few other similar issues. 
-However, the workaround that worked for us involves intercepting the launch arguments in the app delegate and adding 
+You can find the open issue describing this problem on React Native's GitHub repository [Here](https://github.com/facebook/react-native/issues/32350).
+There are many workarounds suggested in this issue's thread and a few other similar issues.
+However, the workaround that worked for us involves intercepting the launch arguments in the app delegate and adding
 a key `UIApplicationLaunchOptionsURLKey`, which React Native expects to be present when calling the `Linking.getInitialURL()` listener.
 
 
 Here's a method to implement this workaround:
 
 
-```swift 
+```swift
 - (NSMutableDictionary *)getLaunchOptionsWithURL:(NSDictionary * _Nullable)launchOptions {
   NSMutableDictionary *launchOptionsWithURL = [NSMutableDictionary dictionaryWithDictionary:launchOptions];
   if (launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
     NSDictionary *remoteNotification = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
-    
+
     if (remoteNotification[@"url"]) {
       NSString *initialURL = remoteNotification[@"url"];
       if (!launchOptions[UIApplicationLaunchOptionsURLKey]) {
@@ -85,7 +85,7 @@ Here's a method to implement this workaround:
 }
 ```
 
-Ensure that this method is called from `application:didFinishLaunchingWithOptions:` before calling the superclass method with the 
+Ensure that this method is called from `application:didFinishLaunchingWithOptions:` before calling the superclass method with the
 modified launch arguments, like so:
 
 
@@ -96,7 +96,7 @@ modified launch arguments, like so:
   self.initialProps = @{};
 
   // some more code ...
-    
+
   NSMutableDictionary * launchOptionsWithURL = [self getLaunchOptionsWithURL:launchOptions];
 
   return [super application:application didFinishLaunchingWithOptions:launchOptionsWithURL];
@@ -104,6 +104,11 @@ modified launch arguments, like so:
 
 ```
 
-This implementation is included in the example app in this repo and can be used for testing. 
+This implementation is included in the example app in this repo and can be used for testing.
 Make sure to use the URL scheme (rntest://) of the example app when testing.
+
+### iOS APNS Token Troubleshooting
+There is an open issue with [`@react-native-firebase/messaging`](https://github.com/invertase/react-native-firebase/issues/8022) where the SDK will uppercase any APNS token returned using `messaging().getAPNSToken()`.
+You can verify this by adding a log the `AppDelegate.m` file that prints the deviceToken (you will need to convert to a hex string).
+APNS Services is case-insensitive, so be sure you are not registering the same device token twice.
 

--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -110,5 +110,5 @@ Make sure to use the URL scheme (rntest://) of the example app when testing.
 ### iOS APNS Token Troubleshooting
 There is an open issue with [`@react-native-firebase/messaging`](https://github.com/invertase/react-native-firebase/issues/8022) where the SDK will uppercase any APNS token returned using `messaging().getAPNSToken()`.
 You can verify this by adding a log the `AppDelegate.m` file that prints the deviceToken (you will need to convert to a hex string).
-APNS Services is case-insensitive, so be sure you are not registering the same device token twice.
+This might have no impact on your use case, but is something to consider when designing.
 


### PR DESCRIPTION
# Description

There's a change (issue?) in the react native firebase SDK we use where the push token from APNS is coming back as all caps, where the APNS API is not returning it in this format. This is just an added warning to the readme that describes the issue. 

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

- updated readme
- 
## Test Plan

## Related Issues/Tickets
CHNL-10057
https://github.com/invertase/react-native-firebase/issues/8022