### PR TITLE
React native 1.0.0 release branch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Android](https://github.com/klaviyo/klaviyo-react-native-sdk/actions/workflows/android-ci.yml/badge.svg?branch=master&event=push)](https://github.com/klaviyo/klaviyo-react-native-sdk/actions/workflows/android-ci.yml)
 [![iOS](https://github.com/klaviyo/klaviyo-react-native-sdk/actions/workflows/ios-ci.yml/badge.svg?branch=master&event=push)](https://github.com/klaviyo/klaviyo-react-native-sdk/actions/workflows/ios-ci.yml)
 
-> ⚠️ This repository is in beta development ⚠️
-
 ## Contents
 
 - [klaviyo-react-native-sdk](#klaviyo-react-native-sdk)
@@ -40,6 +38,8 @@
 
 ## Introduction
 
+> We currently don't have support for expo. This is something we are looking in to and should be available in the future.
+
 The Klaviyo React Native SDK allows developers to incorporate Klaviyo analytics and push notification functionality in
 their React Native applications for Android and iOS. It is a Typescript wrapper (native module bridge) around the native
 Klaviyo iOS and Android SDKs. For more information on the native SDKs, please see the
@@ -55,7 +55,7 @@ push notifications via FCM (Firebase Cloud Messaging) and APNs (Apple Push Notif
 
 ## Requirements
 
-For initial beta release, the SDK was developed and tested against the latest minor release of React Native (0.73+).
+This SDK was developed and tested against the latest minor release of React Native (0.73+).
 We are actively testing and expanding support to the latest patch releases of recent minor versions of React Native.
 
 ### React Native

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ## Introduction
 
-> We currently don't have support for expo. This is something we are looking in to and should be available in the future.
+> We currently don't have support for expo. This is something we are looking into and should be available in the future.
 
 The Klaviyo React Native SDK allows developers to incorporate Klaviyo analytics and push notification functionality in
 their React Native applications for Android and iOS. It is a Typescript wrapper (native module bridge) around the native

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ push notifications via FCM (Firebase Cloud Messaging) and APNs (Apple Push Notif
 
 ## Requirements
 
-This SDK was developed and tested against the latest minor release of React Native (0.73+).
+This SDK was developed and tested against React Native 0.73.
 We are actively testing and expanding support to the latest patch releases of recent minor versions of React Native.
 
 ### React Native

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=2.4.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=3.0.0
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="klaviyo_sdk_version_override">1.0.0</string>
+  <string name="klaviyo_sdk_name_override">react_native</string>
+</resources>

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -5,14 +5,13 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.6)
+    activesupport (7.0.8.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -57,41 +56,38 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
-    minitest (5.22.2)
+    json (2.7.4)
+    minitest (5.25.1)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.9)
     ruby-macho (2.5.1)
-    strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
-    zeitwerk (2.6.13)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   ruby
@@ -101,7 +97,7 @@ DEPENDENCIES
   cocoapods (= 1.15.2)
 
 RUBY VERSION
-   ruby 2.6.10p210
+   ruby 3.3.5p100
 
 BUNDLED WITH
-   1.17.2
+   2.5.22

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -24,9 +24,6 @@ target 'KlaviyoReactNativeSdkExample' do
     :path => config[:reactNativePath],
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
-  
-  #TODO: remove this once iOS modularization release is made and the podspec is updated
-  pod 'KlaviyoSwift', :path => '../../../klaviyo-swift-sdk/'
 
   target 'KlaviyoReactNativeSdkExampleTests' do
     inherit! :complete

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,14 +15,14 @@ PODS:
   - hermes-engine (0.73.1):
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
-  - klaviyo-react-native-sdk (0.4.2):
-    - KlaviyoSwift (= 3.2.0)
+  - klaviyo-react-native-sdk (1.0.0):
+    - KlaviyoSwift (= 4.0.0)
     - React-Core
-  - KlaviyoCore (0.1.0):
+  - KlaviyoCore (4.0.0):
     - AnyCodable-FlightSchool
-  - KlaviyoSwift (3.2.0):
+  - KlaviyoSwift (4.0.0):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 0.1.0)
+    - KlaviyoCore (~> 4.0.0)
   - KlaviyoSwiftExtension (3.3.0)
   - libevent (2.1.12)
   - RCT-Folly (2022.05.16.00):
@@ -1074,7 +1074,6 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
-  - KlaviyoSwift (from `../../../klaviyo-swift-sdk/`)
   - KlaviyoSwiftExtension
   - libevent (~> 2.1.12)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -1127,6 +1126,7 @@ SPEC REPOS:
     - AnyCodable-FlightSchool
     - fmt
     - KlaviyoCore
+    - KlaviyoSwift
     - KlaviyoSwiftExtension
     - libevent
     - SocketRocket
@@ -1147,8 +1147,6 @@ EXTERNAL SOURCES:
     :tag: hermes-2023-11-17-RNv0.73.0-21043a3fc062be445e56a2c10ecd8be028dd9cc5
   klaviyo-react-native-sdk:
     :path: "../.."
-  KlaviyoSwift:
-    :path: "../../../klaviyo-swift-sdk/"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -1243,9 +1241,9 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
-  klaviyo-react-native-sdk: edf2b7ad63175da7c9819811649018e2b10dd2be
-  KlaviyoCore: a1c8bce61e3bf059e2122c68de67c0848ab18691
-  KlaviyoSwift: ae14ca3ab291d212e62ce6a7f75b7f98c117476a
+  klaviyo-react-native-sdk: 3fdd795c641df4e49f18d4805ce559c92d8adbd2
+  KlaviyoCore: 64cf0767bd46055245b778702a55ccc1f18d4eb1
+  KlaviyoSwift: f7ee04bdd50b42dcc6ede4efdeb6f05d1cc4549f
   KlaviyoSwiftExtension: 3094f964d2d1f9ad6815d6543c2d2ffa9297243a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
@@ -1292,6 +1290,6 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
 
-PODFILE CHECKSUM: 9733c70a40fa45d4d6e22abd7d360e3c94c8e69c
+PODFILE CHECKSUM: fb4c6f946002a62b798ca073d975abf271898252
 
 COCOAPODS: 1.15.2

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "3.2.0"
+  s.dependency "KlaviyoSwift", "4.0.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "0.4.2",
+  "version": "1.0.0",
   "description": "Official Klaviyo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
# Description

What's done so far, 

* Pulled in the latest release of the iOS swift SDK - 4.0.0 
* Updated the example iOS app and built it successfully locally. 
* Updated readme to remove beta references 
* Updated readme to indicate no support for expo atm but coming later. 

What's pending?

* Once android SDK is updated, set `KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion` in android/gradle.properties
* Build the local example android app 
* Merge this PR and release. 
