### PR TITLE
[CHNL-12052] Update to include SDK name and version for Android devices

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="klaviyo_react_native_sdk_version">1.0.0</string>
+  <string name="klaviyo_react_native_sdk_name">react_native</string>
+</resources>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_react_native_sdk_version">1.0.0</string>
-  <string name="klaviyo_react_native_sdk_name">react_native</string>
+  <string name="klaviyo_sdk_version_override">1.0.0</string>
+  <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>


### PR DESCRIPTION
# Description
By adding a manifest resource to the SDK, we can reflect in our Android Repo and check if these values exist, which tells our API the user is sending events through react-native and not android native SDK.

# Check List

- [ ] Are you changing anything with the public API?
- [x] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

- adding a new string resource folder for sdk name and version

## Test Plan

- tested with both the android and react example apps to see if the config was properly set, also updated a test to accommodate for the new error logging if the app context is not initialized

## Related Issues/Tickets
CHNL-12052

An important note about this is that technically a react-native SDK user could override this value and throw off our klaviyo config. Maybe we should add this to the README? 
