### PR TITLE
Renaming SDK Name and Version overrides to be more generic

### DIFF
--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -11,9 +11,9 @@
 -->
 <plist version="1.0">
 <dict>
-    <key>react_native_sdk_name</key>
+    <key>klaviyo_sdk_name</key>
     <string>react_native</string>
-    <key>react_native_sdk_version</key>
+    <key>klaviyo_sdk_version</key>
     <string>1.0.0</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "13.0" }
   s.source       = { :git => "https://github.com/klaviyo/klaviyo-react-native-sdk.git", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.resources    = ["ios/klaviyo-react-native-sdk-configuration.plist"]
+  s.resources    = ["ios/klaviyo-sdk-configuration.plist"]
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 


### PR DESCRIPTION
If we're going to support different platforms overriding the native SDK values, we should probably make it named something less "react-native" specific. 

I'll open an ios PR to do this on that side as well