### PR TITLE
set editorconfig settings for Swift & objc files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ root = true
 indent_style = space
 indent_size = 2
 
+[*.{swift,h,m,mm}]
+indent_size = 4
+
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
# Description

This PR modifies the editorconfig to set the indent size to 4 for Swift & Objc file types, to reflect code style conventions