### PR TITLE
Pass along the current activity from react SDK to Android SDK.

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=3.3.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=3.3.1
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=31

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -50,6 +50,10 @@ class KlaviyoReactNativeSdkModule(
 
   @ReactMethod
   fun initialize(apiKey: String) {
+    // Since initialize is being called after Application.onCreate,
+    // we must hand over a reference to the current activity.
+    // The native SDK will track Activity changes internally from here on.
+    currentActivity?.let { Registry.lifecycleMonitor.currentActivity = it }
     Klaviyo.initialize(apiKey, reactContext)
   }
 

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -14,6 +14,7 @@ import com.klaviyo.analytics.model.Keyword
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.core.Registry
+import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.forms.registerForInAppForms
 import java.io.Serializable
 import kotlin.reflect.KVisibility
@@ -49,11 +50,12 @@ class KlaviyoReactNativeSdkModule(
       }
 
   @ReactMethod
+  @OptIn(AdvancedAPI::class)
   fun initialize(apiKey: String) {
     // Since initialize is being called after Application.onCreate,
     // we must hand over a reference to the current activity.
     // The native SDK will track Activity changes internally from here on.
-    currentActivity?.let { Registry.lifecycleMonitor.currentActivity = it }
+    currentActivity?.let(Registry.lifecycleMonitor::assignCurrentActivity)
     Klaviyo.initialize(apiKey, reactContext)
   }
 


### PR DESCRIPTION
Relies on an [Android PR](https://github.com/klaviyo/klaviyo-android-sdk/pull/248) that turned currentActivity into a var.
Can be tested locally with

```
KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=ecm~current-activity-setter-SNAPSHOT
```

I will include the bump to android v 3.3.1 here before merging, just isn't released yet.

# Description

<!-- Briefly describe the feature or bug that your pull request addresses -->

# Check List

- [ ] Are you changing anything with the public API?
- [ ] Are your changes backwards compatible with previous SDK Versions?

## Changelog / Code Overview

<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->

## Test Plan

<!-- How was this code tested / How should reviewers test it? -->

## Related Issues/Tickets

<!-- Link to relevant issues or discussion -->
