### PR TITLE
Potential fix for int to bool conversion

### DIFF
--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -162,13 +162,13 @@ public class KlaviyoBridge: NSObject {
             return
         }
 
+        let fixedProperties = fixNSNumberTypes(event["properties"] as Any)
         let event = Event(
             name: eventType,
-            properties: event["properties"] as? [String: Any],
+            properties: fixedProperties as? [String: Any],
             value: event["value"] as? Double,
             uniqueId: event["uniqueId"] as? String
         )
-
         KlaviyoSDK().create(event: event)
     }
 
@@ -218,6 +218,29 @@ public class KlaviyoBridge: NSObject {
         default:
             return Profile.ProfileKey.custom(customKey: str)
         }
+    }
+
+    static func fixNSNumberTypes(_ value: Any) -> Any {
+        // Handle NSNumber (Bool or Number)
+        if let num = value as? NSNumber {
+            if CFGetTypeID(num) == CFBooleanGetTypeID() {
+                return num.boolValue
+            }
+            return num.intValue
+        }
+
+        // Handle Dictionary
+        if let dict = value as? [String: Any] {
+            return dict.mapValues { fixNSNumberTypes($0) }
+        }
+
+        // Handle Array
+        if let arr = value as? [Any] {
+            return arr.map { fixNSNumberTypes($0) }
+        }
+
+        // Fallback: return as-is
+        return value
     }
 }
 


### PR DESCRIPTION
# Description
In issue #214 a developer noted that 0 and 1s were being converted to false and true when passed in event properties. 


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->


## Test Plan

The fix works but it's hard to test since `print` is less reliable in this case, used proxyman to test after updating the code

| Before | After |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/5d121f73-ad0b-41f7-8fdc-0a2af097b52a)  | ![image](https://github.com/user-attachments/assets/4612b1fd-981c-47e9-a47f-b716694e832d)   | 

I tried to add tests on the native module side but looks like you need a xcode project or a workspace to run the tests (may be there are some workarounds). Tried testing on JS side but have to mock the native module side but that defeats the purpose. Tried to do some testing on playgrounds but that's not very reliable either. 

Code used to do the test 

```
export const sendRandomEvent = async () => {
  try {
    const event: Event = {
      name: getRandomMetric(),
      value: Math.floor(Math.random() * 100),
      properties: {
        quantity: 1,
        AddedItemQuantity: 1,
        number0: 0,
        number1: 1,
        number2: 2,
        number3: 3,
        nestedObject: {
          number0: 0,
          number1: 1,
          number2: 2,
          number3: 3,
        },
        nestedItemsArray: [
          {
            number0: 0,
            number1: 1,
            number2: 2,
            number3: 3,
          },
        ],
      },
      uniqueId: generateRandomName(5),
    };
    Klaviyo.createEvent(event);
  } catch (e: any) {
    console.log(e.message, e.code);
  }
};
```

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->

