### PR TITLE
Utils | Added configure-sdk and bump-version scripts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,8 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.3.1"
+    // Android Gradle Plugin. Best to keep in sync with the klaviyo-android-sdk AGP version
+    classpath "com.android.tools.build:gradle:8.8.0"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,14 +94,26 @@ repositories {
 
 def klaviyoAndroidSdkVersion = getExtOrDefault("klaviyoAndroidSdkVersion")
 def kotlin_version = getExtOrDefault("kotlinVersion")
+def localProperties = new Properties()
+if (rootProject.file("local.properties").canRead()) {
+  localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+}
+def reactNativeAndroidVersion = localProperties['reactNativeAndroidVersion'] ?: ""
+
 
 dependencies {
-  // Production build / once embedded in a react-native app,
-  // the react-native version gets loaded in from the application dependencies.
-  // For < 0.71, this will be from the local maven repo
-  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-  //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-native:+"
+  if (reactNativeAndroidVersion) {
+    // For local development of the SDK code, specify the react-android version to use
+    // So that the SDK can be built and .kt files are linted against a real version of react-native
+    implementation "com.facebook.react:react-android:$reactNativeAndroidVersion"
+  } else {
+    // Production build / once embedded in a react-native app,
+    // the react-native version gets loaded in from the application dependencies.
+    // For < 0.71, this will be from the local maven repo
+    // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"
+  }
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -94,26 +94,15 @@ repositories {
 
 def klaviyoAndroidSdkVersion = getExtOrDefault("klaviyoAndroidSdkVersion")
 def kotlin_version = getExtOrDefault("kotlinVersion")
-def localProperties = new Properties()
-if (rootProject.file("local.properties").canRead()) {
-    localProperties.load(new FileInputStream(rootProject.file("local.properties")))
-}
-def reactNativeAndroidVersion = localProperties['reactNativeAndroidVersion'] ?: ""
-
 
 dependencies {
-  if (reactNativeAndroidVersion) {
-    // For local development of the SDK code, specify the react-android version to use
-    // So that the SDK can be built and .kt files are linted against a real version of react-native
-    implementation "com.facebook.react:react-android:$reactNativeAndroidVersion"
-  } else {
-    // Production build / once embedded in a react-native app,
-    // the react-native version gets loaded in from the application dependencies.
-    // For < 0.71, this will be from the local maven repo
-    // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-    //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:+"
-  }
+  // Production build / once embedded in a react-native app,
+  // the react-native version gets loaded in from the application dependencies.
+  // For < 0.71, this will be from the local maven repo
+  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
+  //noinspection GradleDynamicVersion
+  implementation "com.facebook.react:react-native:+"
+
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // Klaviyo Android SDK

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=feat~iaf-v1.5-SNAPSHOT
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=3.3.1
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=31

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,7 +18,7 @@ KlaviyoReactNativeSdk_targetSdkVersion=31
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_ndkversion=21.4.7075529
 
-# For local SDK development, override these from your local.properties file
+# For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
 localCompositeBuild=false
 localSdkPath=../../klaviyo-android-sdk

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,3 +17,8 @@ KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=31
 KlaviyoReactNativeSdk_compileSdkVersion=31
 KlaviyoReactNativeSdk_ndkversion=21.4.7075529
+
+# For local SDK development, override these from your local.properties file
+# you must set separately for the example app and the library
+localCompositeBuild=false
+localSdkPath=../../klaviyo-android-sdk

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=3.3.1
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=feat~iaf-v1.5-SNAPSHOT
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=31

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -3,10 +3,6 @@
 # Only the base template should be checked in to VCS.
 # Copy this file to `local.properties` to set your local overrides
 
-## Used for local SDK development, so that gradle can locate the
-# correct RN version outside the context of an application
-reactNativeAndroidVersion=0.78.0
-
 # For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
 localCompositeBuild=false

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -6,3 +6,6 @@
 ## Used for local SDK development, so that gradle can locate the
 # correct RN version outside the context of an application
 reactNativeAndroidVersion=0.78.0
+
+localCompositeBuild=true
+localSdkPath=../../klaviyo-android-sdk

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -3,6 +3,10 @@
 # Only the base template should be checked in to VCS.
 # Copy this file to `local.properties` to set your local overrides
 
+## Used for local SDK development, so that gradle can locate the
+# correct RN version outside the context of an application
+reactNativeAndroidVersion=0.78.0
+
 # For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
 localCompositeBuild=false

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -9,5 +9,5 @@ reactNativeAndroidVersion=0.78.0
 
 # For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
-localCompositeBuild=true
+localCompositeBuild=false
 localSdkPath=../../klaviyo-android-sdk

--- a/android/local.properties.template
+++ b/android/local.properties.template
@@ -7,5 +7,7 @@
 # correct RN version outside the context of an application
 reactNativeAndroidVersion=0.78.0
 
+# For local SDK development: set to true in your local.properties file
+# you must set separately for the example app and the library
 localCompositeBuild=true
 localSdkPath=../../klaviyo-android-sdk

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,10 +1,3 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
-plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
-rootProject.name = 'KlaviyoReactNativeSdkExample'
-include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
-
 // Substitute the jitpack SDK dependency for your local instance of the project
 if (localCompositeBuild) {
   def sdkDirectory = new File(localSdkPath)
@@ -12,7 +5,7 @@ if (localCompositeBuild) {
   if (!sdkDirectory.exists()) {
     throw new GradleException("Local Klaviyo Android SDK directory does not exist: " + sdkDirectory.getAbsolutePath())
   } else {
-    print("Configuring composite project with local Klaviyo Android SDK for example app.")
+    print("Configuring composite project with local Klaviyo Android SDK for library.")
   }
 
   includeBuild(sdkDirectory) {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,5 @@
 // Substitute the jitpack SDK dependency for your local instance of the project
-if (localCompositeBuild) {
+if (localCompositeBuild == "true") {
   def sdkDirectory = new File(localSdkPath)
 
   if (!sdkDirectory.exists()) {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,20 +1,28 @@
 // Substitute the jitpack SDK dependency for your local instance of the project
+// Enabling here allows you to develop against a local android SDK for kotlin files in the library module
+if (file("local.properties").canRead()) {
+    def localProperties = new Properties()
+    localProperties.load(new FileInputStream(file("local.properties")))
+    localCompositeBuild = localProperties["localCompositeBuild"] ?: localCompositeBuild
+    localSdkPath = localProperties["localSdkPath"] ?: localSdkPath
+}
+
 if (localCompositeBuild == "true") {
-  def sdkDirectory = new File(localSdkPath)
+    def sdkDirectory = new File(localSdkPath)
 
-  if (!sdkDirectory.exists()) {
-    throw new GradleException("Local Klaviyo Android SDK directory does not exist: " + sdkDirectory.getAbsolutePath())
-  } else {
-    print("Configuring composite project with local Klaviyo Android SDK for library.")
-  }
-
-  includeBuild(sdkDirectory) {
-    dependencySubstitution {
-      // substitute remote dependency with local module
-      substitute module("com.github.klaviyo.klaviyo-android-sdk:core") using project(":sdk:core")
-      substitute module("com.github.klaviyo.klaviyo-android-sdk:analytics") using project(":sdk:analytics")
-      substitute module("com.github.klaviyo.klaviyo-android-sdk:forms") using project(":sdk:forms")
-      substitute module("com.github.klaviyo.klaviyo-android-sdk:push-fcm") using project(":sdk:push-fcm")
+    if (!sdkDirectory.exists()) {
+        throw new GradleException("Local Klaviyo Android SDK directory does not exist: " + sdkDirectory.getAbsolutePath())
+    } else {
+        print("Configuring composite project with local Klaviyo Android SDK for library.")
     }
-  }
+
+    includeBuild(sdkDirectory) {
+        dependencySubstitution {
+            // substitute remote dependency with local module
+            substitute module("com.github.klaviyo.klaviyo-android-sdk:core") using project(":sdk:core")
+            substitute module("com.github.klaviyo.klaviyo-android-sdk:analytics") using project(":sdk:analytics")
+            substitute module("com.github.klaviyo.klaviyo-android-sdk:forms") using project(":sdk:forms")
+            substitute module("com.github.klaviyo.klaviyo-android-sdk:push-fcm") using project(":sdk:push-fcm")
+        }
+    }
 }

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Prompt for the new React SDK version
+read -rp "Enter the new React SDK version: " new_version
+
+# Update SDK version in package.json
+if [[ -f "package.json" ]]; then
+  sed -i '' "0,/\"version\": \".*\"/s//\"version\": \"$new_version\"/" package.json
+  echo "Updated SDK version in package.json."
+else
+  echo "Error: package.json not found."
+  exit 1
+fi
+
+# Update klaviyo_sdk_version in iOS plist file
+plist_file="ios/klaviyo-sdk-configuration.plist"
+if [[ -f "$plist_file" ]]; then
+  /usr/libexec/PlistBuddy -c "Set :klaviyo_sdk_version $new_version" "$plist_file"
+  echo "Updated klaviyo_sdk_version in $plist_file."
+else
+  echo "Error: $plist_file not found."
+  exit 1
+fi
+
+# Update klaviyo_sdk_version_override in Android strings.xml
+android_strings="android/src/main/res/values/strings.xml"
+if [[ -f "$android_strings" ]]; then
+  sed -i '' "s/<string name=\"klaviyo_sdk_version_override\">.*<\/string>/<string name=\"klaviyo_sdk_version_override\">$new_version<\/string>/" "$android_strings"
+  echo "Updated klaviyo_sdk_version_override in $android_strings."
+else
+  echo "Error: $android_strings not found."
+  exit 1
+fi
+
+# Prompt for the Android SDK version
+read -rp "Enter the Android SDK version: " android_version
+
+# Update Android SDK version in gradle.properties
+gradle_properties="./android/gradle.properties"
+if [[ -f "$gradle_properties" ]]; then
+  sed -i '' "s/KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=.*/KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=$android_version/" "$gradle_properties"
+  echo "Updated Android SDK version in $gradle_properties."
+else
+  echo "Error: $gradle_properties not found."
+  exit 1
+fi
+
+# Prompt for the Swift SDK version
+read -rp "Enter the Swift SDK version: " swift_version
+
+# Update Swift SDK version in the podspec
+podspec_file="klaviyo-react-native-sdk.podspec"
+if [[ -f "$podspec_file" ]]; then
+  sed -i '' "s/\"KlaviyoSwift\", \".*\"/\"KlaviyoSwift\", \"$swift_version\"/" "$podspec_file"
+  echo "Updated KlaviyoSwift version in $podspec_file."
+else
+  echo "Error: $podspec_file not found."
+  exit 1
+fi
+
+# Run yarn install or npm install in the example app directory
+example_dir="example"
+if [[ -d "$example_dir" ]]; then
+  echo "Running yarn install in $example_dir..."
+  cd "$example_dir" || exit
+  if ! yarn install; then
+    echo "yarn install failed. Trying npm install..."
+    npm install || { echo "Error: Failed to install dependencies."; exit 1; }
+  fi
+  cd - || exit
+else
+  echo "Error: $example_dir not found."
+  exit 1
+fi
+
+# Run bundle install and pod update in the iOS directory
+ios_dir="$example_dir/ios"
+if [[ -d "$ios_dir" ]]; then
+  cd "$ios_dir" || exit
+  if [[ -f "Gemfile" ]]; then
+    echo "Running bundle install..."
+    bundle install || { echo "Error: Failed to run bundle install."; exit 1; }
+  fi
+  echo "Running pod update for KlaviyoSwift..."
+  bundle exec pod update KlaviyoSwift || { echo "Error: Failed to update pods."; exit 1; }
+  cd - || exit
+else
+  echo "Error: $ios_dir not found."
+  exit 1
+fi
+
+echo "All tasks completed successfully."

--- a/configure-sdk.sh
+++ b/configure-sdk.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# Handle local SDK configuration
+# Reusable function to configure local.properties
+function configure_local_properties() {
+  local android_dir="$1"
+  local enabled="$2" # true or false
+  local sdk_path="$3"
+  local local_properties_file="$android_dir/local.properties"
+  local template_file="$android_dir/local.properties.template"
+
+  # Check if local.properties exists, if not, copy from template
+  if [ ! -f "$local_properties_file" ]; then
+    if [ -f "$template_file" ]; then
+      cp "$template_file" "$local_properties_file"
+      echo "Copied $template_file to $local_properties_file"
+    else
+      echo "Template file $template_file not found. Cannot create $local_properties_file."
+      exit 1
+    fi
+  fi
+
+  # Ensure localCompositeBuild is present and set to requested value
+  if ! grep -q "^localCompositeBuild=" "$local_properties_file"; then
+    echo "localCompositeBuild=$enabled" >> "$local_properties_file"
+    echo "Added localCompositeBuild=$enabled to $local_properties_file"
+  else
+    sed -i '' 's/^localCompositeBuild=.*/localCompositeBuild=true/' "$local_properties_file"
+    echo "Updated localCompositeBuild to $enabled in $local_properties_file"
+  fi
+
+  # Ensure localSdkPath is set in local.properties
+  if [[ -n "$sdk_path" ]]; then
+    if ! grep -q "^localSdkPath=" "$local_properties_file"; then
+      echo "localSdkPath=$sdk_path" >> "$local_properties_file"
+      echo "Added localSdkPath=$sdk_path to $local_properties_file"
+    else
+      sed -i '' "s|^localSdkPath=.*|localSdkPath=$sdk_path|" "$local_properties_file"
+      echo "Updated localSdkPath to $sdk_path in $local_properties_file"
+    fi
+  fi
+}
+
+# Configure local SDK for both directories
+function configure_local_sdk() {
+  local default_sdk_path="../../klaviyo-android-sdk"
+  read -rp "Enter the relative path to klaviyo-android-sdk (default: $default_sdk_path): " sdk_path
+  sdk_path=${sdk_path:-$default_sdk_path}
+
+  configure_local_properties "./android" "true" "$sdk_path"
+  configure_local_properties "./example/android" "true" "../$sdk_path"
+
+  # TODO configure local Swift SDK
+}
+
+# Handle remote SDK configuration
+function configure_remote_sdk() {
+  configure_local_properties "./android" "false"
+  configure_local_properties "./example/android" "false"
+
+  local property_file="./android/gradle.properties"
+  local property_key="KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion"
+
+  if [[ ! -f "$property_file" ]]; then
+    echo "Error: $property_file not found."
+    exit 1
+  fi
+
+  local property_value
+  property_value=$(grep "^$property_key=" "$property_file" | cut -d'=' -f2)
+
+  if [[ -z "$property_value" ]]; then
+    echo "Error: Property '$property_key' not found in $property_file."
+    exit 1
+  fi
+
+  echo "Enter SDK version, branch, or commit hash [return] to skip"
+  echo "(current: $property_value)"
+  read -r sdkVersion
+  sdkVersion=${sdkVersion:-current}
+
+  if [[ -n "$sdkVersion" && "$sdkVersion" != "current" ]]; then
+    # Validate and format SDK version (semantic version or commit hash are unchanged, else assume it is a branch name)
+    if [[ ! "$sdkVersion" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ && ! "$sdkVersion" =~ ^[a-f0-9]{7,40}$ ]]; then
+      # Replace slashes with tildes and append "-SNAPSHOT"
+      sdkVersion="${sdkVersion//\//~}-SNAPSHOT"
+    fi
+
+    if grep -q "^$property_key=" $property_file; then
+      sed -i '' "s/^$property_key=.*/$property_key=$sdkVersion/" $property_file
+    else
+      echo "$property_key=$sdkVersion" >> $property_file
+    fi
+  else
+    echo "Skipping SDK version update."
+    sdkVersion=property_value
+  fi
+
+  echo "Now targeting SDK version: $sdkVersion."
+  echo "You should clean/sync gradle now."
+  echo
+
+  # TODO configure remote Swift SDK
+}
+
+function choose_from_menu() {
+    local prompt="$1" outvar="$2"
+    shift
+    shift
+    local options=("$@") cur=0 count=$# index=0
+
+    # Display prompt
+    echo -n "$prompt"
+    echo
+    echo
+
+    # Save cursor position
+    tput sc
+
+    while true; do
+        # Clear the menu area
+        tput rc
+
+        # Display menu options
+        for ((i=0; i<count; i++)); do
+            if [[ "$i" == "$cur" ]]; then
+                echo -e " \033[38;5;41m>\033[0m\033[38;5;35m${options[$i]}\033[0m"
+            else
+                echo "  ${options[$i]}"
+            fi
+        done
+
+        # Read in pressed key
+        read -rsn1 key
+        if [[ $key == $'\x1b' ]]; then
+            read -rsn2 key
+            case $key in
+                '[A') # Up arrow
+                    cur=$(( $cur - 1 ))
+                    [ "$cur" -lt 0 ] && cur=$((count - 1))
+                    ;;
+                '[B') # Down arrow
+                    cur=$(( $cur + 1 ))
+                    [ "$cur" -ge $count ] && cur=0
+                    ;;
+            esac
+        elif [[ $key == "" ]]; then # Enter key
+            break
+        fi
+    done
+
+    # Pass chosen selection to main body of script
+    eval "$outvar='${options[$cur]}'"
+    echo
+}
+
+# Define menu options
+declare -a selections
+selections=(
+    "Local SDKs"
+    "Remote (JitPack)"
+    "Exit"
+)
+
+# Display header
+tput clear
+echo "This script will help you configure the Klaviyo Android and Swift SDK dependencies"
+echo
+
+# Call menu function
+choose_from_menu "Select an option using arrow keys and press Enter:" selected_choice "${selections[@]}"
+
+# Handle selection
+if [[ "$selected_choice" == "Local SDKs" ]]; then
+  configure_local_sdk
+elif [[ "$selected_choice" == "Remote (JitPack)" ]]; then
+  configure_remote_sdk
+fi

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -53,7 +53,7 @@ publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY
 # and update the applicationId in build.gradle, else the app will crash on launch
 useNativeFirebase=false
 
-# For local SDK development, override these from your local.properties file
+# For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
-localCompositeBuild=true
+localCompositeBuild=false
 localSdkPath=../../../klaviyo-android-sdk

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -52,3 +52,8 @@ publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY
 # Enable Firebase in the example app. You must add your google-services.json file to the project,
 # and update the applicationId in build.gradle, else the app will crash on launch
 useNativeFirebase=false
+
+# For local SDK development, override these from your local.properties file
+# you must set separately for the example app and the library
+localCompositeBuild=true
+localSdkPath=../../../klaviyo-android-sdk

--- a/example/android/local.properties.template
+++ b/example/android/local.properties.template
@@ -13,3 +13,8 @@ publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY
 # Enable Firebase in the example app. You must add your google-services.json file to the project,
 # and update the applicationId in build.gradle, else the app will crash on launch
 useNativeFirebase=false
+
+# For local SDK development, override these from your local.properties file
+# you must set separately for the example app and the library
+localCompositeBuild=true
+localSdkPath=../../../klaviyo-android-sdk

--- a/example/android/local.properties.template
+++ b/example/android/local.properties.template
@@ -14,7 +14,7 @@ publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY
 # and update the applicationId in build.gradle, else the app will crash on launch
 useNativeFirebase=false
 
-# For local SDK development, override these from your local.properties file
+# For local SDK development: set to true in your local.properties file
 # you must set separately for the example app and the library
-localCompositeBuild=true
+localCompositeBuild=false
 localSdkPath=../../../klaviyo-android-sdk

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -6,7 +6,7 @@ include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
 
 // Substitute the jitpack SDK dependency for your local instance of the project
-if (localCompositeBuild) {
+if (localCompositeBuild == "true") {
   def sdkDirectory = new File(localSdkPath)
 
   if (!sdkDirectory.exists()) {

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -6,6 +6,14 @@ include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
 
 // Substitute the jitpack SDK dependency for your local instance of the project
+// Enabling here allows you to build the example app against a local android SDK
+def localProperties = new Properties()
+if (file("local.properties").canRead()) {
+    localProperties.load(new FileInputStream(file("local.properties")))
+    localCompositeBuild=localProperties["localCompositeBuild"] ?: localCompositeBuild
+    localSdkPath = localProperties["localSdkPath"] ?: localSdkPath
+}
+
 if (localCompositeBuild == "true") {
   def sdkDirectory = new File(localSdkPath)
 


### PR DESCRIPTION
# Description
<!-- Briefly describe the feature or bug that your pull request addresses, 1-2 sentences. -->
Added some scripts to make local setup and release prep easier.

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
<!-- What was changed / added / removed and why. Attach screenshots or other supporting materials -->
Scripts:
- `bump-version.sh` walks you through updating version numbers prior to a release, built off our [confluence docs](https://klaviyo.atlassian.net/wiki/spaces/EN/pages/4032725175/React+Native+SDK+Release+Guide).
- `configure-sdk.sh` configures native SDK dependencies, to choose between a local copy, a git branch/commit, or an official release, on each platform, built from our [confluence docs](https://klaviyo.atlassian.net/wiki/spaces/EN/pages/3960799590/React+Native+Setup).

Additionally, fixed targeting a local android SDK from the RN SDK/example app, using the same composite build trick we use in android SDK + test app. This just required a minor gradle/AGP version update in android repos as well, because gradle/AGP must be the same for composite builds. I'm not too concerned about keeping those in sync though, I think as long as we are _ahead_ of the version that RN uses we should be fine, and we last update AGP/gradle in the android repo about a year ago so it'd be good to update.

## Test Plan
<!-- Provide reproducible testing steps. Link any artifacts, recordings, spreadsheets, etc. -->
Run `./bump-version.sh` and follow the prompts, it should update the appropriate version numbers for the RN, Android, and Swift SDKs. Here is an example output:
```
evan.masseau@EvanMasseauMBP klaviyo-react-native-sdk % ./bump-version.sh 
Enter the new React SDK version: 1.3.0
Updated SDK version in package.json.
Updated klaviyo_sdk_version in ios/klaviyo-sdk-configuration.plist.
Updated klaviyo_sdk_version_override in android/src/main/res/values/strings.xml.
Enter the Android SDK version: 3.4.0
Updated Android SDK version in ./android/gradle.properties.
Enter the Swift SDK version: 4.3.0
Updated KlaviyoSwift version in klaviyo-react-native-sdk.podspec.

... It then goes on to run yarn install and pod install.
```

Run `./configure-sdk.sh` and follow the prompts. There is some branching logic here so test:
1. Local: should configure a composite android build and cocoapods to point to `../../../klaviyo-swift-sdk` (with option to override the relative file paths)
2. Remote: using a git branch or commit
3. Remote: using an official release number

Here is an example:
```
This script will help you configure the Klaviyo Android and Swift SDK dependencies

Select an option using arrow keys and press Enter:

 >Local SDKs
  Remote (JitPack)
  Exit

Enter the relative path to klaviyo-android-sdk (default: ../../klaviyo-android-sdk): 

Updated localCompositeBuild to true in ./android/local.properties
Updated localSdkPath to ../../klaviyo-android-sdk in ./android/local.properties

Updated localCompositeBuild to true in ./example/android/local.properties
Updated localSdkPath to ../../../klaviyo-android-sdk in ./example/android/local.properties

Enter the relative path to klaviyo-swift-sdk (default: ../../../klaviyo-swift-sdk): 

Added klaviyo-swift-sdk dependency to ./Podfile with path ../../../klaviyo-swift-sdk
Swift SDK configured successfully.
Do you want to run 'pod install'? (Y/n): n
Skipped 'pod install'.

```

## Related Issues/Tickets
<!-- Link to relevant Jira issues, Slack discussions, Google Docs -->
see https://github.com/klaviyo/klaviyo-android-sdk/pull/278
