### PR TITLE
Chore | Yarn lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - rel/*
 
 permissions:
   contents: write

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -51,6 +51,12 @@ call_lefthook()
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
     fi

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -51,6 +51,12 @@ call_lefthook()
     elif command -v mint >/dev/null 2>&1
     then
       mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
     else
       echo "Can't find lefthook in PATH"
     fi

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/jest": "^29.5.5",
     "@types/react": "19.0.0",
     "del-cli": "^5.1.0",
+    "husky": "^9.1.7",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ft-flow": "^3.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,12 +1585,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@evilmartians/lefthook@npm:^1.5.0":
-  version: 1.11.6
-  resolution: "@evilmartians/lefthook@npm:1.11.6"
+"@evilmartians/lefthook@npm:^1.6.0":
+  version: 1.11.13
+  resolution: "@evilmartians/lefthook@npm:1.11.13"
   bin:
     lefthook: bin/index.js
-  checksum: 4988eb60490d652dec97d182ac30c4271ab19a8ea4c71195da07c9d90c35d384668a6f2da06a016cde0f3682f9e51e602dded07ab8e82db878def6bbf33acf0a
+  checksum: 94d85f52e85c80094f0128e76ae18785e7d7b4950a11de1203f33d9deea14964c86db04d4d6f673ff96cd36d9376d4f231758e8afcce4caf06efdb5552c20a03
   conditions: (os=darwin | os=linux | os=win32) & (cpu=x64 | cpu=arm64 | cpu=ia32)
   languageName: node
   linkType: hard
@@ -8025,7 +8025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "klaviyo-react-native-sdk@workspace:."
   dependencies:
-    "@evilmartians/lefthook": ^1.5.0
+    "@evilmartians/lefthook": ^1.6.0
     "@react-native-community/cli": ^15.0.1
     "@react-native/eslint-config": 0.78.0
     "@release-it/conventional-changelog": ^9.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,6 +6500,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -8036,6 +8045,7 @@ __metadata:
     eslint-config-prettier: ^9.0.0
     eslint-plugin-ft-flow: ^3.0.11
     eslint-plugin-prettier: ^5.0.1
+    husky: ^9.1.7
     jest: ^29.2.1
     lint-staged: ^15.2.0
     prettier: ^3.0.3


### PR DESCRIPTION
One reason CI is failing (aside from half the internet being down) is that a yarn package got updated in this branch without the lockfile being committed. In CI, we run `yarn install --immutable` so it'll throw if anything deviates from the lockfile.

This should unblock the rel/1.3.0 branch's CI, and the PR's branched off it. 