### PR TITLE
IAF | Android constants fix

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -47,7 +47,7 @@ class KlaviyoReactNativeSdkModule(
     T::class
       .nestedClasses
       .filter {
-        it.visibility == KVisibility.PUBLIC && it.objectInstance != null
+        it.visibility == KVisibility.PUBLIC && it.objectInstance is T
       }.associate {
         it.simpleName.toString() to (it.objectInstance as T).name
       }


### PR DESCRIPTION
ProfileKey class now has a companion object inside, which broke our constants extractor. This fixes it so that we're filtering down by type <ProfileKey>