### PR TITLE
Prevent casting of 0/1 number properties to booleans

### DIFF
--- a/example/src/AppViewInterface.ts
+++ b/example/src/AppViewInterface.ts
@@ -15,6 +15,8 @@ import {
   getPushToken,
   registerForInAppForms,
   unregisterFromInAppForms,
+  sendTestEvent,
+  sendTestProfileWithBooleans,
 } from './KlaviyoReactWrapper';
 
 export interface AppViewInterface {
@@ -103,5 +105,15 @@ export const appViews: AppViewInterface[] = [
     title: 'Click to unregister from forms',
     color: '#d3ab10',
     onPress: unregisterFromInAppForms,
+  },
+  {
+    title: 'Click to send an event with booleans and 0/1s',
+    color: '#d3ab10',
+    onPress: sendTestEvent,
+  },
+  {
+    title: 'Click to send an profile property updatet with booleans and 0/1s',
+    color: '#d3ab10',
+    onPress: sendTestProfileWithBooleans,
   },
 ];

--- a/example/src/KlaviyoReactWrapper.ts
+++ b/example/src/KlaviyoReactWrapper.ts
@@ -5,6 +5,7 @@ import {
   type Profile,
   ProfileProperty,
   type FormConfiguration,
+  EventName,
 } from 'klaviyo-react-native-sdk';
 
 import {
@@ -202,6 +203,49 @@ export const sendRandomEvent = async () => {
       uniqueId: generateRandomName(5),
     };
     Klaviyo.createEvent(event);
+  } catch (e: any) {
+    console.log(e.message, e.code);
+  }
+};
+
+export const sendTestEvent = async () => {
+  try {
+    Klaviyo.createEvent({
+      name: EventName.STARTED_CHECKOUT_METRIC,
+      value: 42,
+      properties: {
+        true: true,
+        false: false,
+        number0: 0,
+        number1: 1,
+      },
+    });
+  } catch (e: any) {
+    console.log(e.message, e.code);
+  }
+};
+
+export const sendTestProfileWithBooleans = async () => {
+  try {
+    const myProfile: Profile = {
+      email: generateRandomEmails(),
+      phoneNumber: generateRandomPhoneNumber(),
+      externalId: generateRandomName(8),
+      firstName: 'Test',
+      lastName: generateRandomName(4),
+      organization: generateRandomName(5),
+      title: generateRandomName(6),
+      image: generateRandomName(5),
+      properties: {
+        // Test boolean properties in profile
+        isSubscribed: true,
+        hasConsented: false,
+        numberOfDogs: 0,
+        numberOfCats: 1,
+      },
+    };
+
+    Klaviyo.setProfile(myProfile);
   } catch (e: any) {
     console.log(e.message, e.code);
   }

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -94,7 +94,7 @@ public class KlaviyoBridge: NSObject {
             title: profileDict[ProfileProperty.title.rawValue] as? String,
             image: profileDict[ProfileProperty.image.rawValue] as? String,
             location: location,
-            properties: profileDict[ProfileProperty.properties.rawValue] as? [String: Any]
+            properties: fixNSNumberTypes(profileDict[ProfileProperty.properties.rawValue] as Any) as? [String: Any]
         )
 
         KlaviyoSDK().set(profile: profile)
@@ -174,7 +174,7 @@ public class KlaviyoBridge: NSObject {
 
         let event = Event(
             name: eventType,
-            properties: event["properties"] as? [String: Any],
+            properties: fixNSNumberTypes(event["properties"] as Any) as? [String: Any],
             value: event["value"] as? Double,
             uniqueId: event["uniqueId"] as? String
         )
@@ -228,6 +228,23 @@ public class KlaviyoBridge: NSObject {
         default:
             return Profile.ProfileKey.custom(customKey: str)
         }
+    }
+
+    // check to ensure bools and numbers are preserved as their types between the RN/Swift layers
+    static func fixNSNumberTypes(_ value: Any) -> Any {
+        if let num = value as? NSNumber {
+            if CFGetTypeID(num) == CFBooleanGetTypeID() {
+                return num.boolValue
+            }
+            return num.intValue
+        }
+        if let dict = value as? [String: Any] {
+            return dict.mapValues { fixNSNumberTypes($0) }
+        }
+        if let arr = value as? [Any] {
+            return arr.map { fixNSNumberTypes($0) }
+        }
+        return value
     }
 }
 


### PR DESCRIPTION
# Description
In the RN to Swift transmission, the types can be wrapped in a NSNumber that then casts them into booleans if possible rather than preserving them as 0s and 1s. This extra helper  `fixNSNumberTypes` preserves that for any data structure we are passing as a property. Applied this fixer to both event properties and profile properties as that is where we are allowing any freeform structure that could be affected by this. Other properties like email/phone already have their own validation.



## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Adds fixNSNumberTypes to KlaviyoBridge to prevent 0/1 to bool casting

## Test Plan
Wanted to add unit tests but there is not much testing infrastructure in this repo at this point. Manually tested with two events (added to the example app) and saw on the Klaviyo Developer logs it did appear as the expected types:

<img width="518" height="439" alt="image" src="https://github.com/user-attachments/assets/3a4424af-4f05-43a1-a0f3-6c8834cca367" />
<img width="488" height="608" alt="image" src="https://github.com/user-attachments/assets/34e5e223-3748-4620-bee0-3213452479cd" />



## Related Issues/Tickets
Addresses https://github.com/klaviyo/klaviyo-react-native-sdk/issues/214
https://klaviyo.atlassian.net/browse/CHNL-21194

