### PR TITLE
Backwards compatible module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
-  "main": "lib/commonjs/index.js",
-  "module": "lib/module/index.js",
-  "react-native": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "main": "./lib/commonjs/index.js",
+  "module": "./lib/module/index.js",
+  "react-native": "./lib/module/index.js",
+  "types": "./lib/typescript/src/index.d.ts",
   "exports": {
     ".": {
       "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,18 +3,16 @@
   "version": "2.0.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
-  "main": "./lib/commonjs/index.js",
-  "module": "./lib/module/index.js",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "react-native": "lib/module/index.js",
+  "types": "lib/typescript/src/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./lib/typescript/module/src/index.d.ts",
-        "default": "./lib/module/index.js"
-      },
-      "require": {
-        "types": "./lib/typescript/commonjs/src/index.d.ts",
-        "default": "./lib/commonjs/index.js"
-      }
+      "types": "./lib/typescript/src/index.d.ts",
+      "react-native": "./lib/module/index.js",
+      "import": "./lib/module/index.js",
+      "require": "./lib/commonjs/index.js"
     }
   },
   "files": [
@@ -187,8 +185,7 @@
       [
         "typescript",
         {
-          "project": "tsconfig.build.json",
-          "esm": true
+          "project": "tsconfig.build.json"
         }
       ]
     ]


### PR DESCRIPTION
# Description
Addresses the issue [here](https://github.com/klaviyo/klaviyo-react-native-sdk/issues/212) where the new architecture support broke imports for the original RN module resolution method (node). This fix explicitly defines the types older RN projects expect. This is additive to the existing support to the modern module resolution methods (like bundler, that our project and example uses).

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Changelog / Code Overview
- Adds backwards support for older moduleResolution


## Test Plan
I recreated the error on a starter project by setting the `"moduleResolution": "node"` 
<img width="350" height="163" alt="image" src="https://github.com/user-attachments/assets/82d21463-faa1-4f26-a425-c246e2c67189" />
and `npm install klaviyo-react-native-sdk` (version 2.0.1) -- when I tried to import Klaviyo:
<img width="499" height="174" alt="image" src="https://github.com/user-attachments/assets/b24b51b6-986e-484b-b947-6be05d9e559d" />

Targeting this change locally, there is no more error.
<img width="479" height="43" alt="image" src="https://github.com/user-attachments/assets/0cc8ad71-f00a-44c2-95cd-3bff3d4952e8" />

Also verified this with our example app that uses `"Bundler"` as the moduleResolution and our test app that uses an undefined default (at this point, presumably also `"bundler"`)

## Related Issues/Tickets
https://klaviyo.atlassian.net/browse/CHNL-20867
#212 

