### PR TITLE
Consume universal links branches of mobile SDKs

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.0.1
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=feat~universal_link_support-SNAPSHOT
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -21,6 +21,9 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
+  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'master'
+  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'master'
+  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'master'
 
   use_react_native!(
     :path => config[:reactNativePath],


### PR DESCRIPTION
# Description
In order to get CI to run while we do dev work for Universal Links, we need to point the React Native SDK to consume unpublished versions of the iOS and Android SDKs. This is a temporary change that should be reverted before merging this feature branch into `master`.