### PR TITLE
[CHNL-24362][Android] wired up Android deep link handler

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoDeepLinkEventEmitter.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoDeepLinkEventEmitter.kt
@@ -13,13 +13,6 @@ class KlaviyoDeepLinkEventEmitter(
   companion object {
     const val NAME = "KlaviyoDeepLinkEventEmitter"
     private const val DEEP_LINK_EVENT = "klaviyoDeepLink"
-    private var sharedInstance: KlaviyoDeepLinkEventEmitter? = null
-
-    fun getSharedInstance(): KlaviyoDeepLinkEventEmitter? = sharedInstance
-  }
-
-  init {
-    sharedInstance = this
   }
 
   override fun getName(): String = NAME

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoDeepLinkEventEmitter.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoDeepLinkEventEmitter.kt
@@ -1,0 +1,44 @@
+package com.klaviyoreactnativesdk
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.klaviyo.analytics.Klaviyo
+
+class KlaviyoDeepLinkEventEmitter(
+  private val reactContext: ReactApplicationContext,
+) : com.facebook.react.bridge.ReactContextBaseJavaModule(reactContext) {
+  companion object {
+    const val NAME = "KlaviyoDeepLinkEventEmitter"
+    private const val DEEP_LINK_EVENT = "klaviyoDeepLink"
+    private var sharedInstance: KlaviyoDeepLinkEventEmitter? = null
+
+    fun getSharedInstance(): KlaviyoDeepLinkEventEmitter? = sharedInstance
+  }
+
+  init {
+    sharedInstance = this
+  }
+
+  override fun getName(): String = NAME
+
+  fun emitDeepLinkEvent(url: String) {
+    val params: WritableMap =
+      Arguments.createMap().apply {
+        putString("url", url)
+      }
+
+    reactContext
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      .emit(DEEP_LINK_EVENT, params)
+  }
+
+  @ReactMethod
+  fun registerDeepLinkHandler() {
+    Klaviyo.registerDeepLinkHandler { uri ->
+      emitDeepLinkEvent(uri.toString())
+    }
+  }
+}

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -15,6 +15,7 @@ import com.klaviyo.analytics.model.Keyword
 import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.core.Registry
+import com.klaviyo.core.config.Config
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.forms.InAppFormsConfig
 import com.klaviyo.forms.registerForInAppForms
@@ -169,6 +170,13 @@ class KlaviyoReactNativeSdkModule(
     if (urlStr.isEmpty()) {
       Registry.log.warning("[Klaviyo React Native SDK] Empty tracking link provided")
       return
+    }
+
+    if (!Registry.isRegistered<Config>()) {
+      // If the SDK has not been initialized yet, we cannot handle the link without providing Context to Klaviyo SDK
+      reactApplicationContext.currentActivity?.let {
+        Klaviyo.registerForLifecycleCallbacks(it)
+      }
     }
 
     Klaviyo.handleUniversalTrackingLink(urlStr)

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkPackage.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkPackage.kt
@@ -9,6 +9,7 @@ class KlaviyoReactNativeSdkPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
     listOf(
       KlaviyoReactNativeSdkModule(reactContext),
+      KlaviyoDeepLinkEventEmitter(reactContext),
     )
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> = emptyList()

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,18 @@
           <!-- Accepts URIs that begin with "klaviyosample://” -->
           <data android:scheme="klaviyosample"/>
         </intent-filter>
+
+        <!-- Android Installation Step 2b: Configure verified app links for Universal Link Click Tracking -->
+        <intent-filter android:label="app_link_handler" android:autoVerify="true">
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="http" />
+          <data android:scheme="https" />
+          <data android:host="trk.your.domain.com" />
+          <data android:pathPrefix="/u/" />
+        </intent-filter>
+
       </activity>
 
       <!-- Android Installation Step 2b: Register KlaviyoPushService to receive MESSAGING_EVENT intents. -->

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="http" />
           <data android:scheme="https" />
           <data android:host="trk.your.domain.com" />
           <data android:pathPrefix="/u/" />

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -44,7 +44,7 @@ hermesEnabled=true
 # Set your own configuration here, or make an untracked local.properties file by copying local.properties.template
 
 # Configures whether Klaviyo.initialize() is called from native java/kotlin layer, or javascript/typescript layer
-initializeKlaviyoFromNative=false
+initializeKlaviyoFromNative=true
 
 # Set your public Klaviyo API key
 publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -44,7 +44,7 @@ hermesEnabled=true
 # Set your own configuration here, or make an untracked local.properties file by copying local.properties.template
 
 # Configures whether Klaviyo.initialize() is called from native java/kotlin layer, or javascript/typescript layer
-initializeKlaviyoFromNative=true
+initializeKlaviyoFromNative=false
 
 # Set your public Klaviyo API key
 publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,14 +4,22 @@ import { Button, View } from 'react-native';
 import { type AppViewInterface, appViews } from './AppViewInterface';
 import { styles } from './Styles';
 import { Linking } from 'react-native';
+import { Klaviyo } from 'klaviyo-react-native-sdk';
 
 export default function App() {
   useEffect(() => {
     Linking.addEventListener('url', ({ url }) => {
       console.log('Event Listener: url', url);
+      Klaviyo.handleUniversalTrackingLink(url);
     });
     Linking.getInitialURL().then((url) => {
       console.log('Initial Url: url', url);
+      if (url != null) {
+        Klaviyo.handleUniversalTrackingLink(url);
+      }
+    });
+    Klaviyo.registerDeepLinkHandler((url) => {
+      console.log('Klaviyo deep link: url', url);
     });
   }, []);
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,18 +8,25 @@ import { Klaviyo } from 'klaviyo-react-native-sdk';
 
 export default function App() {
   useEffect(() => {
-    Linking.addEventListener('url', ({ url }) => {
-      console.log('Event Listener: url', url);
-      Klaviyo.handleUniversalTrackingLink(url);
-    });
+    // Get initial URL, if app opened with a link
     Linking.getInitialURL().then((url) => {
-      console.log('Initial Url: url', url);
-      if (url != null) {
-        Klaviyo.handleUniversalTrackingLink(url);
+      if (Klaviyo.handleUniversalTrackingLink(url)) {
+        console.log('Initial Url: Klaviyo tracking link', url);
+      } else {
+        console.log('Initial Url: url', url);
       }
     });
+    // Listen for deep link events now that the app is running
+    Linking.addEventListener('url', ({ url }) => {
+      if (Klaviyo.handleUniversalTrackingLink(url)) {
+        console.log('Event Listener: Klaviyo tracking link', url);
+      } else {
+        console.log('Event Listener: url', url);
+      }
+    });
+    // Register handler to handle any deep links originating from Klaviyo
     Klaviyo.registerDeepLinkHandler((url) => {
-      console.log('Klaviyo deep link: url', url);
+      console.log('Klaviyo Deep Link: destination url', url);
     });
   }, []);
 

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -75,11 +75,4 @@ export interface KlaviyoEventAPI {
    * @param event - The event to track
    */
   createEvent(event: Event): void;
-
-  /**
-   * Resolves a Klaviyo tracking link to a Universal Link URL,
-   * then handles navigation to the resolved URL.
-   * @param trackingLink - The tracking link to be handled
-   */
-  handleUniversalTrackingLink(trackingLink: string): void;
 }

--- a/src/KlaviyoDeepLinkAPI.ts
+++ b/src/KlaviyoDeepLinkAPI.ts
@@ -18,7 +18,7 @@ export interface KlaviyoDeepLinkAPI {
    * @param trackingLink - The tracking link to be handled
    * @returns {boolean} - Whether the link was handled successfully
    */
-  handleUniversalTrackingLink(trackingLink: string): boolean;
+  handleUniversalTrackingLink(trackingLink: string | null): boolean;
 
   /**
    * Registers a deep link handler that will be called when a deep link is received.

--- a/src/KlaviyoDeepLinkAPI.ts
+++ b/src/KlaviyoDeepLinkAPI.ts
@@ -9,6 +9,18 @@ export type DeepLinkHandler = (url: string) => void;
  */
 export interface KlaviyoDeepLinkAPI {
   /**
+   * Resolves a Klaviyo tracking link to a Universal Link URL,
+   * then handles navigation to the resolved URL.
+   * The link must be a valid Klaviyo universal tracking link:
+   * - Uses HTTPS protocol
+   * - Path starts with '/u/'
+   *
+   * @param trackingLink - The tracking link to be handled
+   * @returns {boolean} - Whether the link was handled successfully
+   */
+  handleUniversalTrackingLink(trackingLink: string): boolean;
+
+  /**
    * Registers a deep link handler that will be called when a deep link is received.
    * The handler will be invoked with the deep link URL as a string parameter.
    *

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -266,10 +266,11 @@ describe('Klaviyo SDK', () => {
   });
 
   describe('tracking links', () => {
-    it('should call the native handleUniversalTrackingLink method with a valid URL', () => {
-      const trackingLink = 'https://example.com/tracking/abc123';
+    it('should call the native handleUniversalTrackingLink method with a valid Klaviyo universal tracking link', () => {
+      const trackingLink = 'https://klaviyo.com/u/abc123';
 
-      Klaviyo.handleUniversalTrackingLink(trackingLink);
+      const result = Klaviyo.handleUniversalTrackingLink(trackingLink);
+      expect(result).toBe(true);
       expect(
         NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
       ).toHaveBeenCalledWith(trackingLink);
@@ -282,8 +283,8 @@ describe('Klaviyo SDK', () => {
       // Create spy on console.error
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
-      Klaviyo.handleUniversalTrackingLink('');
-
+      const result = Klaviyo.handleUniversalTrackingLink('');
+      expect(result).toBe(false);
       expect(
         NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
       ).not.toHaveBeenCalled();
@@ -300,13 +301,68 @@ describe('Klaviyo SDK', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
       // @ts-ignore - intentionally testing invalid input
-      Klaviyo.handleUniversalTrackingLink(null);
-
+      const result = Klaviyo.handleUniversalTrackingLink(null);
+      expect(result).toBe(false);
       expect(
         NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
       ).not.toHaveBeenCalled();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[Klaviyo] Error: Empty tracking link provided'
+      );
+
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not call the native handleUniversalTrackingLink method with an invalid URL format', () => {
+      // Create spy on console.error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const result = Klaviyo.handleUniversalTrackingLink('not-a-valid-url');
+      expect(result).toBe(false);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
+      ).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Klaviyo] Error: Invalid URL format'
+      );
+
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not call the native handleUniversalTrackingLink method with a non-HTTPS URL', () => {
+      // Create spy on console.error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const result = Klaviyo.handleUniversalTrackingLink(
+        'http://klaviyo.com/u/abc123'
+      );
+      expect(result).toBe(false);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
+      ).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Klaviyo] Error: Invalid Klaviyo universal tracking link format'
+      );
+
+      // Restore console.error
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not call the native handleUniversalTrackingLink method with a URL that does not have a /u/ path', () => {
+      // Create spy on console.error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const result = Klaviyo.handleUniversalTrackingLink(
+        'https://klaviyo.com/track/abc123'
+      );
+      expect(result).toBe(false);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.handleUniversalTrackingLink
+      ).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Klaviyo] Error: Invalid Klaviyo universal tracking link format'
       );
 
       // Restore console.error

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,7 +80,7 @@ export const Klaviyo: KlaviyoInterface = {
    * then handles navigation to the resolved URL.
    * @param urlStr - The tracking link to be handled
    */
-  handleUniversalTrackingLink(urlStr: string): boolean {
+  handleUniversalTrackingLink(urlStr: string | null): boolean {
     if (!urlStr || urlStr.trim() === '') {
       console.error('[Klaviyo] Error: Empty tracking link provided');
       return false;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,12 +80,29 @@ export const Klaviyo: KlaviyoInterface = {
    * then handles navigation to the resolved URL.
    * @param urlStr - The tracking link to be handled
    */
-  handleUniversalTrackingLink(urlStr: string) {
+  handleUniversalTrackingLink(urlStr: string): boolean {
     if (!urlStr || urlStr.trim() === '') {
       console.error('[Klaviyo] Error: Empty tracking link provided');
-      return;
+      return false;
     }
-    KlaviyoReactNativeSdk.handleUniversalTrackingLink(urlStr);
+
+    // Validate that the URL is a Klaviyo universal tracking link
+    try {
+      const url = new URL(urlStr);
+      const isValidScheme = url.protocol === 'https:';
+      const isValidPath = url.pathname.startsWith('/u/');
+
+      if (!isValidScheme || !isValidPath) {
+        console.warn('[Klaviyo] Warning: Not a Klaviyo tracking link');
+        return false;
+      }
+
+      KlaviyoReactNativeSdk.handleUniversalTrackingLink(urlStr);
+      return true;
+    } catch (error) {
+      console.error('[Klaviyo] Error: Invalid URL format');
+      return false;
+    }
   },
   registerDeepLinkHandler(handler: DeepLinkHandler): void {
     // Initialize the event emitter if not already done


### PR DESCRIPTION
# Description
Following up on #260, this PR implements the Android part of the deep link handler. Se the description on that PR for greater detail.

https://klaviyo.atlassian.net/browse/CHNL-24362

## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [x] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.


## Test Plan
I registered a deep link handler in the React Native test app, then invoked the deep link via an In-App Form. The GIF below shows an alert being displayed when the deep link is invoked.

![rn android](https://github.com/user-attachments/assets/ac098abe-6a46-46b5-9dbe-2cec463bfc00)