### PR TITLE
Consume Swift SDK v5.0.3

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.0.2</string>
+  <string name="klaviyo_sdk_version_override">2.0.3</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -9,18 +9,18 @@ PODS:
   - hermes-engine (0.78.0):
     - hermes-engine/Pre-built (= 0.78.0)
   - hermes-engine/Pre-built (0.78.0)
-  - klaviyo-react-native-sdk (2.0.2):
-    - KlaviyoForms (= 5.0.2)
-    - KlaviyoSwift (= 5.0.2)
+  - klaviyo-react-native-sdk (2.0.3):
+    - KlaviyoForms (= 5.0.3)
+    - KlaviyoSwift (= 5.0.3)
     - React-Core
-  - KlaviyoCore (5.0.2):
+  - KlaviyoCore (5.0.3):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.0.2):
-    - KlaviyoSwift (~> 5.0.2)
-  - KlaviyoSwift (5.0.2):
+  - KlaviyoForms (5.0.3):
+    - KlaviyoSwift (~> 5.0.3)
+  - KlaviyoSwift (5.0.3):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.0.2)
-  - KlaviyoSwiftExtension (5.0.2)
+    - KlaviyoCore (~> 5.0.3)
+  - KlaviyoSwiftExtension (5.0.3)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1768,11 +1768,11 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  klaviyo-react-native-sdk: bd5cb9cf23d06851b762c4e50c471e8186f4efb1
-  KlaviyoCore: b5756601aa1a36d9c52a2482129678ea12fb6fd8
-  KlaviyoForms: 8bd518b140115b1ddd5e892b7b12844fe1ce245e
-  KlaviyoSwift: 995930ec8a87596950ff2cfc6340ac66e626e913
-  KlaviyoSwiftExtension: 3ba7570f45e9cc2873de73e79e27b4af46ed6553
+  klaviyo-react-native-sdk: 6ec57c4319e2093ef177fd5b30d45ff610eda519
+  KlaviyoCore: a700d5e3a2c829beba5f8a7211f5b01cd7a993fc
+  KlaviyoForms: 8f0081135848e91492fadc57da80d0c73688327a
+  KlaviyoSwift: 0ce884b48219aa830c93e2d4bed4d1552fcde5dd
+  KlaviyoSwiftExtension: 1b6d6c97ed62071a5b07873f34cef1b30f45c74e
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
@@ -1832,7 +1832,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 299e99fc57c93edc7c5396ef1a39a3a4d494f25d
   ReactCommon: c8fdbc582b98a07daf201cd95c1da75dd029f3ee
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: d89d04d86b5af18317f481166dccc48213d26927
+  Yoga: be02ca501b03c79d7027a6bbbd0a8db985034f11
 
 PODFILE CHECKSUM: e20d7567686b77a54d5ef38de82fae4c1448f77a
 

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.0.2</string>
+	<string>2.0.3</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.0.2"
-  s.dependency "KlaviyoForms", "5.0.2"
+  s.dependency "KlaviyoSwift", "5.0.3"
+  s.dependency "KlaviyoForms", "5.0.3"
 
   s.default_subspecs = :none
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
# Description
This PR bumps the React Native SDK to version 2.0.3, and tells the RN SDK to consume [version 5.0.3](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/5.0.3) of the Swift SDK. The Swift update fixes an issue on iOS 26 devices in which an in-app form could get opened in another app.


## Due Diligence
<!-- Best practices before submitting, add additional notes below -->
- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations
<!-- Help determine how this should be categorized for release, add additional notes below. -->
<!-- Please add the planned version as a `milestone` label on this PR -->
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
  - If so, please merge to a feature branch so documentation updates only go live upon official release.
- [ ] This is planned work for an upcoming release.
  - If no, author or reviewer should account for this in a release plan, or describe why not below.