### PR TITLE
RN | example app | Universal linking

### DIFF
--- a/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
+++ b/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
@@ -3,17 +3,17 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
 
-
 @implementation AppDelegate
 
 // Change to NO if you don't want debug alerts or logs.
 BOOL isDebug = YES;
 
-// Change to NO if you prefer to initialize and handle push tokens in the React Native layer
+// Change to NO if you prefer to initialize and handle push tokens in the React
+// Native layer
 BOOL useNativeImplementation = YES;
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   self.moduleName = @"KlaviyoReactNativeSdkExample";
   self.initialProps = @{};
 
@@ -21,9 +21,10 @@ BOOL useNativeImplementation = YES;
   [UNUserNotificationCenter currentNotificationCenter].delegate = self;
 
   if (useNativeImplementation) {
-    // iOS Installation Step 3: Initialize the SDK with public key, if initializing from native code
-    // Exclude if initializing from react native layer
-    [PushNotificationsHelper initializeSDK: @"YOUR_KLAVIYO_PUBLIC_API_KEY"];
+    // iOS Installation Step 3: Initialize the SDK with public key, if
+    // initializing from native code Exclude if initializing from react native
+    // layer
+    [PushNotificationsHelper initializeSDK:@"Xr5bFG"];
 
     // iOS Installation Step 4: Request notification permission from the user
     // Exclude if handling permissions from react native layer
@@ -33,13 +34,17 @@ BOOL useNativeImplementation = YES;
   }
 
   // refer to installation step 16 below
-  NSMutableDictionary * launchOptionsWithURL = [self getLaunchOptionsWithURL:launchOptions];
+  NSMutableDictionary *launchOptionsWithURL =
+      [self getLaunchOptionsWithURL:launchOptions];
 
-  return [super application:application didFinishLaunchingWithOptions:launchOptionsWithURL];
+  return [super application:application
+      didFinishLaunchingWithOptions:launchOptionsWithURL];
 }
 
-// iOS Installation Step 6: Implement this delegate to receive and set the push token
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+// iOS Installation Step 6: Implement this delegate to receive and set the push
+// token
+- (void)application:(UIApplication *)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
   if (useNativeImplementation) {
     // iOS Installation Step 7: set the push token to Klaviyo SDK
     // Exclude if handling push tokens from react native layer
@@ -49,52 +54,72 @@ BOOL useNativeImplementation = YES;
   }
 
   if (isDebug) {
-      NSString *token = [self stringFromDeviceToken:deviceToken];
-      NSLog(@"Device Token: %@", token);
+    NSString *token = [self stringFromDeviceToken:deviceToken];
+    NSLog(@"Device Token: %@", token);
   }
 }
 
-// iOS Installation Step 8: [Optional] Implement this if registering with APNs fails
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+// iOS Installation Step 8: [Optional] Implement this if registering with APNs
+// fails
+- (void)application:(UIApplication *)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
   if (isDebug) {
     NSLog(@"Failed to register for remote notifications: %@", error);
   }
 }
 
-// iOS Installation Step 9: Implement the delegate didReceiveNotificationResponse to response to user actions (tapping on push) push notifications
-// when the app is in the background
-// NOTE: this delegate will NOT be called if iOS Installation Step 2 is not done.
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler {
-  // iOS Installation Step 10: call `handleReceivingPushWithResponse` method and pass in the below arguments.
-  // Note that handleReceivingPushWithResponse calls our SDK and is something that has to be implemented in your app as well.
-  // Further, if you want to intercept urls instead of them being routed to the system and system calling `application:openURL:options:` you can implement the `deepLinkHandler` below
-  [PushNotificationsHelper handleReceivingPushWithResponse:response completionHandler:completionHandler deepLinkHandler:^(NSURL * _Nonnull url) {
-    NSLog(@"URL is %@", url);
-    [RCTLinkingManager application:UIApplication.sharedApplication openURL: url options: @{}];
-  }];
+// iOS Installation Step 9: Implement the delegate
+// didReceiveNotificationResponse to response to user actions (tapping on push)
+// push notifications when the app is in the background NOTE: this delegate will
+// NOT be called if iOS Installation Step 2 is not done.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+    didReceiveNotificationResponse:(UNNotificationResponse *)response
+             withCompletionHandler:(void (^)())completionHandler {
+  // iOS Installation Step 10: call `handleReceivingPushWithResponse` method and
+  // pass in the below arguments. Note that handleReceivingPushWithResponse
+  // calls our SDK and is something that has to be implemented in your app as
+  // well. Further, if you want to intercept urls instead of them being routed
+  // to the system and system calling `application:openURL:options:` you can
+  // implement the `deepLinkHandler` below
+  [PushNotificationsHelper
+      handleReceivingPushWithResponse:response
+                    completionHandler:completionHandler
+                      deepLinkHandler:^(NSURL *_Nonnull url) {
+                        NSLog(@"URL is %@", url);
+                        [RCTLinkingManager
+                            application:UIApplication.sharedApplication
+                                openURL:url
+                                options:@{}];
+                      }];
 
-  // iOS Installation Step 9a: update the app count to current badge number - 1. You can also set this to 0 if you
-  // no longer want the badge to show.
-  [PushNotificationsHelper updateBadgeCount: [UIApplication sharedApplication].applicationIconBadgeNumber - 1];
+  // iOS Installation Step 9a: update the app count to current badge number - 1.
+  // You can also set this to 0 if you no longer want the badge to show.
+  [PushNotificationsHelper updateBadgeCount:[UIApplication sharedApplication]
+                                                .applicationIconBadgeNumber -
+                                            1];
 
   if (isDebug) {
     UIAlertController *alert = [UIAlertController
-                                alertControllerWithTitle:@"Push Notification"
-                                message:@"handled background notifications"
-                                preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction
-                      actionWithTitle:@"OK"
-                      style:UIAlertActionStyleDefault
-                      handler:nil]];
-    [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        alertControllerWithTitle:@"Push Notification"
+                         message:@"handled background notifications"
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+                                              style:UIAlertActionStyleDefault
+                                            handler:nil]];
+    [self.window.rootViewController presentViewController:alert
+                                                 animated:YES
+                                               completion:nil];
   }
 }
 
-// iOS Installation Step 11: Implement the delegate willPresentNotification to handle push notifications when the app is in the foreground
-// NOTE: this delegate will NOT be called if iOS Installation Step 2 is not done.
+// iOS Installation Step 11: Implement the delegate willPresentNotification to
+// handle push notifications when the app is in the foreground NOTE: this
+// delegate will NOT be called if iOS Installation Step 2 is not done.
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
        willPresentNotification:(UNNotification *)notification
-         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+         withCompletionHandler:
+             (void (^)(UNNotificationPresentationOptions options))
+                 completionHandler {
   if (isDebug) {
     NSDictionary *userInfo = notification.request.content.userInfo;
     // Handle the push notification payload as needed
@@ -102,72 +127,105 @@ BOOL useNativeImplementation = YES;
     // Example: Display an alert with the notification message
     NSString *message = userInfo[@"aps"][@"alert"][@"body"];
     UIAlertController *alert = [UIAlertController
-                                alertControllerWithTitle:@"Push Notification"
-                                message:message
-                                preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-    [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
+        alertControllerWithTitle:@"Push Notification"
+                         message:message
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+                                              style:UIAlertActionStyleDefault
+                                            handler:nil]];
+    [self.window.rootViewController presentViewController:alert
+                                                 animated:YES
+                                               completion:nil];
   }
 
-  // iOS Installation Step 12: call the completion handler with presentation options here, such as showing a banner or playing a sound.
-  completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
+  // iOS Installation Step 12: call the completion handler with presentation
+  // options here, such as showing a banner or playing a sound.
+  completionHandler(UNNotificationPresentationOptionAlert |
+                    UNNotificationPresentationOptionBadge |
+                    UNNotificationPresentationOptionSound);
 }
 
-// iOS Installation Step 13: Implement this method to receive deep link. There are some addition setup steps needed as mentioned in the readme here -
+// iOS Installation Step 13: Implement this method to receive deep link. There
+// are some addition setup steps needed as mentioned in the readme here -
 // https://github.com/klaviyo/klaviyo-swift-sdk?tab=readme-ov-file#deep-linking
-// Calling `RCTLinkingManager` is required for your react native listeners to be called
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+// Calling `RCTLinkingManager` is required for your react native listeners to be
+// called
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:
+                (NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
   return [RCTLinkingManager application:app openURL:url options:options];
 }
 
-// iOS Installation Step 14: if you want to reset the app badge count whenever the app becomes active implement this
-// delegate method and set the badge count to 0. Note that this may sometimes mean that the user would miss the
+// iOS Installation Step 13a: Implement this method to handle Universal Links
+// (https://) This is required for Klaviyo universal tracking links and other
+// HTTPS deep links Calling `RCTLinkingManager` forwards the universal link to
+// your React Native code
+- (BOOL)application:(UIApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:
+          (void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))
+              restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+// iOS Installation Step 14: if you want to reset the app badge count whenever
+// the app becomes active implement this delegate method and set the badge count
+// to 0. Note that this may sometimes mean that the user would miss the
 // notification.
 - (void)applicationDidBecomeActive:(UIApplication *)application {
   [PushNotificationsHelper updateBadgeCount:0];
 }
 
-
-// iOS Installation Step 16: call this method from `application:didFinishLaunchingWithOptions:` before calling the super class method with
-// the launch arguments. This is a workaround for a react issue where if the app is terminated the deep link isn't sent to the react native layer
-// when it is coming from a remote notification.
+// iOS Installation Step 16: call this method from
+// `application:didFinishLaunchingWithOptions:` before calling the super class
+// method with the launch arguments. This is a workaround for a react issue
+// where if the app is terminated the deep link isn't sent to the react native
+// layer when it is coming from a remote notification.
 // https://github.com/facebook/react-native/issues/32350
-- (NSMutableDictionary *)getLaunchOptionsWithURL:(NSDictionary * _Nullable)launchOptions {
-  NSMutableDictionary *launchOptionsWithURL = [NSMutableDictionary dictionaryWithDictionary:launchOptions];
+- (NSMutableDictionary *)getLaunchOptionsWithURL:
+    (NSDictionary *_Nullable)launchOptions {
+  NSMutableDictionary *launchOptionsWithURL =
+      [NSMutableDictionary dictionaryWithDictionary:launchOptions];
   if (launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
-    NSDictionary *remoteNotification = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
+    NSDictionary *remoteNotification =
+        launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
 
     if (remoteNotification[@"url"]) {
       NSString *initialURL = remoteNotification[@"url"];
       if (!launchOptions[UIApplicationLaunchOptionsURLKey]) {
-        launchOptionsWithURL[UIApplicationLaunchOptionsURLKey] = [NSURL URLWithString:initialURL];
+        launchOptionsWithURL[UIApplicationLaunchOptionsURLKey] =
+            [NSURL URLWithString:initialURL];
       }
     }
   }
   return launchOptionsWithURL;
 }
 
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
   return [self bundleURL];
 }
 
-- (NSURL *)bundleURL
-{
+- (NSURL *)bundleURL {
 #if DEBUG
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+  return
+      [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  return [[NSBundle mainBundle] URLForResource:@"main"
+                                 withExtension:@"jsbundle"];
 #endif
 }
 
 - (NSString *)stringFromDeviceToken:(NSData *)deviceToken {
-    const unsigned char *tokenBytes = (const unsigned char *)[deviceToken bytes];
-    NSMutableString *token = [NSMutableString stringWithCapacity:([deviceToken length] * 2)];
-    for (NSUInteger i = 0; i < [deviceToken length]; i++) {
-        [token appendFormat:@"%02x", tokenBytes[i]];
-    }
-    return token;
+  const unsigned char *tokenBytes = (const unsigned char *)[deviceToken bytes];
+  NSMutableString *token =
+      [NSMutableString stringWithCapacity:([deviceToken length] * 2)];
+  for (NSUInteger i = 0; i < [deviceToken length]; i++) {
+    [token appendFormat:@"%02x", tokenBytes[i]];
+  }
+  return token;
 }
 
 @end

--- a/example/ios/KlaviyoReactNativeSdkExample/KlaviyoReactNativeSdkExample.entitlements
+++ b/example/ios/KlaviyoReactNativeSdkExample/KlaviyoReactNativeSdkExample.entitlements
@@ -4,6 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:theonewhoknocks.work</string>
+		<string>applinks:trk.theonewhoknocks.work</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.reactjs.native.example.KlaviyoReactNativeSdkExample.shared</string>


### PR DESCRIPTION
# Description

Added universal links support to the example app by implementing the required iOS delegate method and configuring Associated Domains. This enables the example app to handle universal links.

![Simulator Screen Recording - iPhone 16 Pro - 2025-10-02 at 22 52 34](https://github.com/user-attachments/assets/5efaf836-0108-49d0-86b0-6b56eded78ca)

Also, updated the AASA file with RN SDK example app. Ex - https://trk.theonewhoknocks.work/.well-known/apple-app-site-association

## Due Diligence
- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable). *(Android App Links already configured)*

## Release/Versioning Considerations
- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Example app improvements to demonstrate SDK functionality.

## Changelog / Code Overview

### Added
**iOS Universal Links Handler (`AppDelegate.mm`)**
- Added `application:continueUserActivity:restorationHandler:` delegate method (Installation Step 13a)
- Forwards universal links to React Native's `RCTLinkingManager` for handling in JS layer
- Enables HTTPS deep links including Klaviyo universal tracking links

**Associated Domains Configuration (`KlaviyoReactNativeSdkExample.entitlements`)**
- Added `com.apple.developer.associated-domains` entitlement
- Configured `applinks:trk.theonewhoknocks.work` domain for testing universal links
- App now declares it can handle links from the tracking domain

### Why
- The example app already has the React Native code to handle universal tracking links via `Klaviyo.handleUniversalTrackingLink()`
- The native iOS delegate method was missing, so universal links would open in Safari instead of the app
- This completes the universal links implementation chain: AASA file → Associated Domains → AppDelegate → React Native Linking API → Klaviyo SDK

### Impact
- Example app now serves as a complete reference implementation for universal links
- Developers can test the full flow: click tracking link → app opens → `handleUniversalTrackingLink()` processes it
- Matches the setup documented in the README's Deep Linking section

## Test Plan

**Verified universal links work:**
1. Configure AASA file at `https://trk.theonewhoknocks.work/.well-known/apple-app-site-association` with app ID `G3793W2RJ2.org.reactjs.native.example.KlaviyoReactNativeSdkExample`
2. Install example app on iOS device/simulator
3. Open a Klaviyo tracking link (e.g., `https://trk.theonewhoknocks.work/u/01K6GCRR0VNT8ZSN9CBG3TSPEK_0`) in Safari or Reminders app
4. Verify app opens instead of browser
5. Verify React Native `Linking` event listener receives the URL
6. Verify `Klaviyo.handleUniversalTrackingLink()` returns `true` and processes the link

**Code changes:**
- AppDelegate now has both custom URL scheme handler (`application:openURL:options:`) and universal links handler (`application:continueUserActivity:restorationHandler:`)
- Entitlements file declares the tracking domain
- Both handlers forward URLs to `RCTLinkingManager` for React Native processing

## Related Issues/Tickets

Completes universal links setup for the example app, demonstrating the functionality added in the Universal Link Support PR (#265).