### PR TITLE
Configure stale bot for label-driven approach

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           only-labels: 'awaiting-reporter-response,missing-details'
+          remove-stale-when-updated: true
           days-before-issue-stale: 14
           days-before-issue-close: 14
           stale-issue-label: 'stale'


### PR DESCRIPTION
## Summary
This PR configures the stale bot to use a label-driven approach for managing stale issues. The bot will now only process issues that are specifically marked as awaiting information from the reporter.

## Changes
- Added `only-labels` parameter to restrict bot to issues labeled `awaiting-reporter-response` or `missing-details`
- Updated exempt labels to `evergreen`, `investigating`, and `awaiting-team` (removed auto-applied `bug` and `feature-request` labels)
- Changed timing: issues marked stale after 14 days, closed after additional 14 days (28 days total)
- Updated cron schedule to run at noon Eastern (5pm UTC)
- Kept original message copy with corrected timing references

## Benefits
- **More targeted approach**: Only issues awaiting reporter response are affected
- **Protected important issues**: Issues under investigation or awaiting team action won't be automatically closed
- **Clear communication**: Messages accurately reflect the timing and reason for closure
- **Prevents false positives**: Maintainers must explicitly mark issues before bot processes them

## How It Works
1. Maintainer requests info from reporter and adds `awaiting-reporter-response` or `missing-details` label
2. After 14 days of inactivity, bot marks issue as stale
3. After 14 more days without response (28 days total), issue is automatically closed
4. If reporter responds at any time, remove the label to stop the stale countdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure stale bot to only act on labeled issues, adjust issue timing/messages, expand exempt labels, and shift the cron schedule.
> 
> - **CI/GitHub Actions** (`.github/workflows/stale.yml`):
>   - **Label-driven processing**: add `only-labels` (`awaiting-reporter-response,missing-details`) and `remove-stale-when-updated: true`.
>   - **Issue timings/messages**: change `days-before-issue-close` 10→14; update stale/close messages to reflect 14/28 days.
>   - **Exempt labels**: expand `exempt-issue-labels` to `evergreen,investigating,awaiting-team`.
>   - **Schedule**: adjust cron to `0 17 * * *`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dda35c4b43e5aab456b74470020e79f9a248eff9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->