### PR TITLE
Add simple android config to control location permissions in merged manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
     - [Prerequisites](#prerequisites-2)
     - [Setup](#setup-2)
       - [Android Location Permissions](#android-location-permissions)
-      - [Registering for Geofencing](#registering-for-geofencing)
+      - [iOS Location Permissions](#ios-location-permissions)
     - [Unregistering from Geofencing](#unregistering-from-geofencing)
   - [Troubleshooting](#troubleshooting)
   - [Contributing](#contributing)
@@ -618,6 +618,14 @@ To enable geofencing in your app, you must:
 
 1. Configure location permissions in your app's platform-specific configuration files
 2. Call `Klaviyo.registerGeofencing()` after initializing the SDK
+
+```typescript
+import { Klaviyo } from 'klaviyo-react-native-sdk';
+
+// After initializing with your public API key
+Klaviyo.registerGeofencing();
+```
+
 3. Prompt the user to grant background location permissions at run time
 
 #### Android Location Permissions
@@ -636,16 +644,9 @@ If your app doesn't use geofencing, or you prefer to declare the permissions in 
 klaviyoIncludeLocationPermissions=false
 ```
 
-#### Registering for Geofencing
+#### iOS Location Permissions
 
-After configuring permissions, register for geofencing after initializing the SDK:
-
-```typescript
-import { Klaviyo } from 'klaviyo-react-native-sdk';
-
-// After initializing with your public API key
-Klaviyo.registerGeofencing();
-```
+The Klaviyo React Native SDK does not automatically set up permissions to support geofencing on iOS. You must implement them yourself following the [native instructions](https://github.com/klaviyo/klaviyo-swift-sdk/tree/rel/5.2.0-alpha.1?tab=readme-ov-file#geofencing) to add the necessary keys to the Info.plist if your app utilizes geofencing.
 
 ### Unregistering from Geofencing
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
   - [Geofencing](#geofencing)
     - [Prerequisites](#prerequisites-2)
     - [Setup](#setup-2)
+      - [Android Location Permissions](#android-location-permissions)
+      - [Registering for Geofencing](#registering-for-geofencing)
     - [Unregistering from Geofencing](#unregistering-from-geofencing)
   - [Troubleshooting](#troubleshooting)
   - [Contributing](#contributing)
@@ -616,15 +618,34 @@ To enable geofencing in your app, you must:
 
 1. Configure location permissions in your app's platform-specific configuration files
 2. Call `Klaviyo.registerGeofencing()` after initializing the SDK
+3. Prompt the user to grant background location permissions at run time
 
-3. Register for geofencing after initializing the SDK:
+#### Android Location Permissions
 
-   ```typescript
-   import { Klaviyo } from 'klaviyo-react-native-sdk';
+By default, the Klaviyo React Native SDK includes these manifest declarations for the android location permissions required for geofencing.
 
-   // After initializing with your public API key
-   Klaviyo.registerGeofencing();
-   ```
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+If your app doesn't use geofencing, or you prefer to declare the permissions in your own app manifest, add the following to your `android/gradle.properties`:
+
+```properties
+klaviyoIncludeLocationPermissions=false
+```
+
+#### Registering for Geofencing
+
+After configuring permissions, register for geofencing after initializing the SDK:
+
+```typescript
+import { Klaviyo } from 'klaviyo-react-native-sdk';
+
+// After initializing with your public API key
+Klaviyo.registerGeofencing();
+```
 
 ### Unregistering from Geofencing
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,6 +90,13 @@ repositories {
 
 def klaviyoAndroidSdkVersion = getExtOrDefault("klaviyoAndroidSdkVersion")
 def kotlin_version = getExtOrDefault("kotlinVersion")
+
+// Whether to include location permissions from Klaviyo's location module.
+// Set klaviyoIncludeLocationPermissions=false in your gradle.properties to exclude them.
+// When false, apps using geofencing must declare location permissions in their own manifest.
+def includeLocationPermissions = rootProject.hasProperty('klaviyoIncludeLocationPermissions')
+    ? rootProject.property('klaviyoIncludeLocationPermissions').toBoolean()
+    : true
 def localProperties = new Properties()
 if (rootProject.file("local.properties").canRead()) {
   localProperties.load(new FileInputStream(rootProject.file("local.properties")))
@@ -117,7 +124,12 @@ dependencies {
   api "com.github.klaviyo.klaviyo-android-sdk:analytics:$klaviyoAndroidSdkVersion"
   api "com.github.klaviyo.klaviyo-android-sdk:push-fcm:$klaviyoAndroidSdkVersion"
   api "com.github.klaviyo.klaviyo-android-sdk:forms:$klaviyoAndroidSdkVersion"
-  api "com.github.klaviyo.klaviyo-android-sdk:location:$klaviyoAndroidSdkVersion"
+  if (includeLocationPermissions) {
+    api "com.github.klaviyo.klaviyo-android-sdk:location:$klaviyoAndroidSdkVersion"
+  } else {
+    // TODO: Update version once Android SDK releases noPermissions flavor
+    api "com.github.klaviyo.klaviyo-android-sdk:location:feat~flutter-support-SNAPSHOT:noPermissions@aar"
+  }
   implementation "com.github.klaviyo.klaviyo-android-sdk:core:$klaviyoAndroidSdkVersion"
 
   // We used reflection to enumerate keywords in the Klaviyo Android SDK dynamically

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,8 +127,7 @@ dependencies {
   if (includeLocationPermissions) {
     api "com.github.klaviyo.klaviyo-android-sdk:location:$klaviyoAndroidSdkVersion"
   } else {
-    // TODO: Update version once Android SDK releases noPermissions flavor
-    api "com.github.klaviyo.klaviyo-android-sdk:location:feat~flutter-support-SNAPSHOT:noPermissions@aar"
+    api "com.github.klaviyo.klaviyo-android-sdk:location-no-permissions:$klaviyoAndroidSdkVersion"
   }
   implementation "com.github.klaviyo.klaviyo-android-sdk:core:$klaviyoAndroidSdkVersion"
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -46,6 +46,10 @@ hermesEnabled=true
 # Configures whether Klaviyo.initialize() is called from native java/kotlin layer, or javascript/typescript layer
 initializeKlaviyoFromNative=true
 
+# Include location permissions from Klaviyo's location module (for geofencing support).
+# Set to false to exclude location permissions from the merged manifest.
+klaviyoIncludeLocationPermissions=true
+
 # Set your public Klaviyo API key
 publicApiKey=YOUR_KLAVIYO_PUBLIC_API_KEY
 


### PR DESCRIPTION
# Description
The Klaviyo Android SDK's location module declares location permissions that appear in consuming apps' merged manifests even if they don't use geofencing. This causes app store review concerns for developers. In this android SDK update https://github.com/klaviyo/klaviyo-android-sdk/pull/408 I'm creating a new build variant that excludes that permission, but otherwise uses identical code. This PR adds a gradle flag to the RN SDK to toggle between the two dependencies, leaving it up the host app developer whether to include the permission. 

Opted to default it to `true` (include the permissions) because
- Since the setting is not easily discovered, better to keep dev X simple by defaulting to a fully-featured set up. Those not using it can easily opt out. 
- Best for backward compatibility -- I don't think we can just disable the permission in a patch version. We can also go by community feedback, if it becomes clear that it is more burdensome, we can change it in at least a minor, if not a major version release.
  - Side note: on Expo we can also add a config option that uses the same gradle flag under the hood. Best we default to _false_ there because the setup is much more discoverable and we already defaulted ios geofencing to false as well. 


**Do not merge until official android release is ready**

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - Verified via `aapt dump permissions` on built APK
- [ ] I have added sufficient unit/integration tests of my changes.
  - Manual verification only; manifest merging is build-time
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - iOS doesn't have this issue since permissions are declared in Info.plist by the app developer

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - This is a hotfix addressing user complaints about location permissions appearing in apps that don't use geofencing.

## Changelog / Code Overview

**New Gradle Property**
- Added `klaviyoIncludeLocationPermissions` as a gradle property in the RN SDK. If false, it will use the new permissionless flavor of the android SDK's location module.

**README:**
- Updated geofencing setup docs to explain the android permission situation

**Example App:**
- Added explicit opt in with the gradle property (although not required, since the default is true)

## Test Plan
Pack the RN SDK, target the packed SDK with the example app, and then build the example app with the new gradle flag set to true and false. Use `aapt dump permissions app-debug.apk | grep -i location` to check for the permissions

1. Build example app with gradle flag set to true → verify that locaiton permission is present
2. Build example app with gradle flag set to false → verify location permissions is absent from APK


## Related Issues/Tickets

Addressing user feedback about location permissions causing app store review issues for apps not using geofencing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)