### PR TITLE
[MAGE-444] feat(example/ios): differentiate silent from standard push with content-available

### DIFF
--- a/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
+++ b/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
@@ -205,6 +205,10 @@ BOOL useNativeImplementation = YES;
                                                    animated:YES
                                                  completion:nil];
     }
+  } else if (apsPayload[@"content-available"]) {
+    if (isDebug) {
+      NSLog(@"Standard Push with Background Processing: %@", userInfo);
+    }
   }
 
   // You MUST call the completion handler within ~30 seconds.

--- a/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
+++ b/example/ios/KlaviyoReactNativeSdkExample/AppDelegate.mm
@@ -179,6 +179,40 @@ BOOL useNativeImplementation = YES;
   [PushNotificationsHelper updateBadgeCount:0];
 }
 
+// iOS Installation Step 15: Handle silent push notifications (content-available: 1).
+// This method fires for both pure silent pushes and standard pushes that carry
+// content-available. Only forward pure silent pushes (no aps.alert) for background
+// processing — standard pushes are handled by willPresent/didReceive.
+- (void)application:(UIApplication *)application
+    didReceiveRemoteNotification:(NSDictionary *)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+  NSDictionary *apsPayload = userInfo[@"aps"];
+  BOOL hasVisibleContent = apsPayload[@"alert"] != nil;
+
+  if (!hasVisibleContent) {
+    [PushNotificationsHelper handleSilentPushWithUserInfo:userInfo];
+
+    if (isDebug) {
+      NSString *payload = [NSString stringWithFormat:@"%@", userInfo];
+      UIAlertController *alert = [UIAlertController
+          alertControllerWithTitle:@"Silent Push Received"
+                           message:payload
+                    preferredStyle:UIAlertControllerStyleAlert];
+      [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+                                                style:UIAlertActionStyleDefault
+                                              handler:nil]];
+      [self.window.rootViewController presentViewController:alert
+                                                   animated:YES
+                                                 completion:nil];
+    }
+  }
+
+  // You MUST call the completion handler within ~30 seconds.
+  // Failing to do so will cause iOS to throttle or stop delivering
+  // silent push notifications to your app.
+  completionHandler(UIBackgroundFetchResultNewData);
+}
+
 // iOS Installation Step 16: call this method from
 // `application:didFinishLaunchingWithOptions:` before calling the super class
 // method with the launch arguments. This is a workaround for a react issue

--- a/example/ios/KlaviyoReactNativeSdkExample/PushNotificationsHelper.swift
+++ b/example/ios/KlaviyoReactNativeSdkExample/PushNotificationsHelper.swift
@@ -41,6 +41,12 @@ class PushNotificationsHelper: NSObject {
   }
 
   @objc
+  static func handleSilentPush(userInfo: NSDictionary) {
+    NSLog("[Klaviyo] Silent push received: %@", userInfo)
+    // Perform background work here, e.g. prefetch content or sync state.
+  }
+
+  @objc
   static func handleReceivingPush(
     response: UNNotificationResponse,
     completionHandler: @escaping () -> Void,


### PR DESCRIPTION
# Description

`didReceiveRemoteNotification` fires for two distinct scenarios that should be handled differently:

- **Pure silent push** (`content-available: 1`, no `alert` in `aps`) — delivered silently with no banner. Forwarded to `PushNotificationsHelper.handleSilentPush` for background processing.
- **Standard push + content-available** — visible notification that also carries `content-available`. Handled by `willPresent`/`didReceive`; no silent-push forwarding needed.

Consistent with the differentiation implemented in the Flutter SDK example app (klaviyo/klaviyo-flutter-sdk#72).

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- **`AppDelegate.mm`**: Add `didReceiveRemoteNotification:fetchCompletionHandler:` with differentiation logic. Pure silent pushes call `handleSilentPushWithUserInfo:` and (when `isDebug=YES`) show a UIAlertController. Standard pushes with `content-available` are ignored here and handled by `willPresent`/`didReceive`.
- **`PushNotificationsHelper.swift`**: Add `handleSilentPush(userInfo:)` as the designated hook for background processing on silent push delivery.

## Test Plan

1. Send a **pure silent push** (`content-available: 1`, no `alert`) → "Silent Push Received" alert appears in debug builds
2. Send a **standard push with content-available** (`content-available: 1` + `alert`) → notification banner shows normally, no silent-push alert
3. Send a **standard push without content-available** → normal notification behaviour unchanged

## Related Issues/Tickets

Resolves MAGE-444