### PR TITLE
feat: Add form lifecycle event bridge for in-app forms (#334)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
 # saved: 4.3.1
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=0a48d79980dc3f276422cf9c42ff145eb39f364a
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=rel~4.4.0-SNAPSHOT
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,7 +17,8 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.3.1
+# saved: 4.3.1
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=0a48d79980dc3f276422cf9c42ff145eb39f364a
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -8,6 +8,8 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.klaviyo.analytics.Klaviyo
 import com.klaviyo.analytics.model.Event
 import com.klaviyo.analytics.model.EventKey
@@ -19,9 +21,12 @@ import com.klaviyo.core.MissingKlaviyoModule
 import com.klaviyo.core.Registry
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.utils.AdvancedAPI
+import com.klaviyo.forms.FormLifecycleEvent
 import com.klaviyo.forms.FormsProvider
 import com.klaviyo.forms.InAppFormsConfig
 import com.klaviyo.forms.registerForInAppForms
+import com.klaviyo.forms.registerFormLifecycleHandler
+import com.klaviyo.forms.unregisterFormLifecycleHandler
 import com.klaviyo.forms.unregisterFromInAppForms
 import com.klaviyo.location.GeofencingProvider
 import com.klaviyo.location.LocationManager
@@ -38,6 +43,15 @@ class KlaviyoReactNativeSdkModule(
     const val NAME = "KlaviyoReactNativeSdk"
     private const val LOCATION = "location"
     private const val PROPERTIES = "properties"
+  }
+
+  private fun sendEvent(
+    eventName: String,
+    params: WritableMap?,
+  ) {
+    reactContext
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      .emit(eventName, params)
   }
 
   override fun getName(): String = NAME
@@ -288,4 +302,56 @@ class KlaviyoReactNativeSdkModule(
 
     Klaviyo.createEvent(event = klaviyoEvent)
   }
+
+  @ReactMethod
+  fun registerFormLifecycleHandler() {
+    UiThreadUtil.runOnUiThread {
+      try {
+        Klaviyo.registerFormLifecycleHandler { event ->
+          val params =
+            Arguments.createMap().apply {
+              putString("formId", event.formId)
+              putString("formName", event.formName)
+              when (event) {
+                is FormLifecycleEvent.FormShown -> {
+                  putString("type", "formShown")
+                }
+
+                is FormLifecycleEvent.FormDismissed -> {
+                  putString("type", "formDismissed")
+                }
+
+                is FormLifecycleEvent.FormCtaClicked -> {
+                  putString("type", "formCtaClicked")
+                  putString("buttonLabel", event.buttonLabel)
+                  putString("deepLinkUrl", event.deepLinkUrl.toString())
+                }
+              }
+            }
+
+          sendEvent("FormLifecycleEvent", params)
+        }
+      } catch (e: MissingKlaviyoModule) {
+        Registry.log.error("Forms module is not available", e)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun unregisterFormLifecycleHandler() {
+    UiThreadUtil.runOnUiThread {
+      try {
+        Klaviyo.unregisterFormLifecycleHandler()
+      } catch (e: MissingKlaviyoModule) {
+        Registry.log.error("Forms module is not available", e)
+      }
+    }
+  }
+
+  // Required by NativeEventEmitter on the JS side
+  @ReactMethod
+  fun addListener(eventName: String) {}
+
+  @ReactMethod
+  fun removeListeners(count: Int) {}
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,10 +28,10 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
-  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
-  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
-  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
-  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
+  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
+  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
+  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
+  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
 
   # Setup permissions for react-native-permissions
   setup_permissions([

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,6 +28,10 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
+  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
+  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
+  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
+  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => 'e90dbb943b053c9fa62f75732e8fc0c3025514f4'
 
   # Setup permissions for react-native-permissions
   setup_permissions([

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -10,19 +10,19 @@ PODS:
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
   - klaviyo-react-native-sdk (2.3.1):
-    - KlaviyoForms (= 5.2.2)
-    - KlaviyoLocation (= 5.2.2)
-    - KlaviyoSwift (= 5.2.2)
+    - KlaviyoForms
+    - KlaviyoLocation
+    - KlaviyoSwift
     - React-Core
-  - KlaviyoCore (5.2.2):
+  - KlaviyoCore (5.3.0):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.2.2):
-    - KlaviyoSwift (~> 5.2.2)
-  - KlaviyoLocation (5.2.2):
-    - KlaviyoSwift (~> 5.2.2)
-  - KlaviyoSwift (5.2.2):
+  - KlaviyoForms (5.3.0):
+    - KlaviyoSwift (~> 5.3.0)
+  - KlaviyoLocation (5.3.0):
+    - KlaviyoSwift (~> 5.3.0)
+  - KlaviyoSwift (5.3.0):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.2.2)
+    - KlaviyoCore (~> 5.3.0)
   - KlaviyoSwiftExtension (5.2.1)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -2396,6 +2396,10 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
+  - KlaviyoCore (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
+  - KlaviyoForms (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
+  - KlaviyoLocation (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
+  - KlaviyoSwift (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
   - KlaviyoSwiftExtension
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2469,10 +2473,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AnyCodable-FlightSchool
-    - KlaviyoCore
-    - KlaviyoForms
-    - KlaviyoLocation
-    - KlaviyoSwift
     - KlaviyoSwiftExtension
     - SocketRocket
 
@@ -2494,6 +2494,18 @@ EXTERNAL SOURCES:
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
   klaviyo-react-native-sdk:
     :path: "../.."
+  KlaviyoCore:
+    :branch: rel/5.3.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoForms:
+    :branch: rel/5.3.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoLocation:
+    :branch: rel/5.3.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwift:
+    :branch: rel/5.3.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2627,6 +2639,20 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
+CHECKOUT OPTIONS:
+  KlaviyoCore:
+    :commit: 082f13c3c0696cfc973c3f63907d35e0bf26b9ff
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoForms:
+    :commit: 082f13c3c0696cfc973c3f63907d35e0bf26b9ff
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoLocation:
+    :commit: 082f13c3c0696cfc973c3f63907d35e0bf26b9ff
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwift:
+    :commit: 082f13c3c0696cfc973c3f63907d35e0bf26b9ff
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+
 SPEC CHECKSUMS:
   AnyCodable-FlightSchool: 261cbe76757802b17d471b9059b21e6fa5edf57b
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -2636,13 +2662,13 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 308ea86b6b48d10be7127aba51f5800167122b7d
-  KlaviyoCore: 0104cec11bbc1c5838f9a232ea420d15a43bbdfb
-  KlaviyoForms: 4be515497a79df4876b950eb1de5742dc42754e0
-  KlaviyoLocation: edb041d083080aacdf052bc2f6a3b708ec76a721
-  KlaviyoSwift: 596bf5471ec37eed2773ffc603b3026895b93bb8
+  klaviyo-react-native-sdk: 8ee6035a0dff7eab0de01cbf128883c330df0879
+  KlaviyoCore: 0d27552664bb46b171e8256b92a3af94e7261a00
+  KlaviyoForms: 589f91cb245dbf78f657cbc46a1d3dab47bef601
+  KlaviyoLocation: 9ba7810b0cbe1205dad0903c42dc420ba8dd6025
+  KlaviyoSwift: 844dda154601d17f1b6a95dca8e5e6dd918b4664
   KlaviyoSwiftExtension: 310a32489eeca1b2a540903a55028b1ffef6b070
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788
@@ -2708,8 +2734,8 @@ SPEC CHECKSUMS:
   ReactCommon: 5cfd842fcd893bb40fc835f98fadc60c42906a20
   RNPermissions: 86933bcc014e7fa7d77e09b7b0b0b858287d611f
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 1e91d83a5286cfd3b725eade59274c92270540d4
+  Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: 03bdd0145df6393c4c141686be3a82ab1eb4ee5d
+PODFILE CHECKSUM: d7648bc76ebfe99a4d62dbb22c4635482634202a
 
 COCOAPODS: 1.15.2

--- a/example/src/KlaviyoReactWrapper.ts
+++ b/example/src/KlaviyoReactWrapper.ts
@@ -6,6 +6,7 @@ import {
   ProfileProperty,
   type FormConfiguration,
   type FormLifecycleEvent,
+  FormLifecycleEventType,
 } from 'klaviyo-react-native-sdk';
 
 import {
@@ -40,13 +41,13 @@ export const initialize = async () => {
       );
 
       switch (event.type) {
-        case 'formShown':
+        case FormLifecycleEventType.Shown:
           console.log(`Form ${event.formId}${nameInfo} is being shown`);
           break;
-        case 'formDismissed':
+        case FormLifecycleEventType.Dismissed:
           console.log(`Form ${event.formId}${nameInfo} was dismissed`);
           break;
-        case 'formCtaClicked':
+        case FormLifecycleEventType.CtaClicked:
           console.log(
             `Form ${event.formId}${nameInfo} CTA was clicked: ${event.buttonLabel}, deep link: ${event.deepLinkUrl}`
           );

--- a/example/src/KlaviyoReactWrapper.ts
+++ b/example/src/KlaviyoReactWrapper.ts
@@ -5,6 +5,7 @@ import {
   type Profile,
   ProfileProperty,
   type FormConfiguration,
+  type FormLifecycleEvent,
 } from 'klaviyo-react-native-sdk';
 
 import {
@@ -30,6 +31,28 @@ export const initialize = async () => {
     // Alternate iOS Installation Step 3
     // Initialize the SDK with public key, if initializing from React Native
     Klaviyo.initialize('YOUR_KLAVIYO_PUBLIC_API_KEY');
+
+    // Register form lifecycle handler to log events
+    Klaviyo.registerFormLifecycleHandler((event: FormLifecycleEvent) => {
+      const nameInfo = event.formName ? ` (${event.formName})` : '';
+      console.log(
+        `[Form Lifecycle] ${event.type}: Form ${event.formId}${nameInfo}`
+      );
+
+      switch (event.type) {
+        case 'formShown':
+          console.log(`Form ${event.formId}${nameInfo} is being shown`);
+          break;
+        case 'formDismissed':
+          console.log(`Form ${event.formId}${nameInfo} was dismissed`);
+          break;
+        case 'formCtaClicked':
+          console.log(
+            `Form ${event.formId}${nameInfo} CTA was clicked: ${event.buttonLabel}, deep link: ${event.deepLinkUrl}`
+          );
+          break;
+      }
+    });
   } catch (e: any) {
     console.log(e.message, e.code);
   }

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -94,6 +94,38 @@ public class KlaviyoBridge: NSObject {
 
     @MainActor
     @objc
+    public static func registerFormLifecycleHandler(callback: @escaping ([String: Any]) -> Void) {
+        #if canImport(KlaviyoForms)
+        KlaviyoSDK().registerFormLifecycleHandler { event in
+            var params: [String: Any] = [
+                "formId": event.formId as Any,
+                "formName": event.formName as Any
+            ]
+            switch event {
+            case .formShown:
+                params["type"] = "formShown"
+            case .formDismissed:
+                params["type"] = "formDismissed"
+            case let .formCtaClicked(_, _, buttonLabel, deepLinkUrl):
+                params["type"] = "formCtaClicked"
+                params["buttonLabel"] = buttonLabel as Any
+                params["deepLinkUrl"] = deepLinkUrl.absoluteString as Any
+            }
+            callback(params)
+        }
+        #endif
+    }
+
+    @MainActor
+    @objc
+    public static func unregisterFormLifecycleHandler() {
+        #if canImport(KlaviyoForms)
+        KlaviyoSDK().unregisterFormLifecycleHandler()
+        #endif
+    }
+
+    @MainActor
+    @objc
     public static func registerGeofencing() {
         #if canImport(KlaviyoLocation)
         KlaviyoSDK().registerGeofencing()

--- a/ios/KlaviyoReactNativeSdk.h
+++ b/ios/KlaviyoReactNativeSdk.h
@@ -1,6 +1,6 @@
 
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface KlaviyoReactNativeSdk : NSObject <RCTBridgeModule>
+@interface KlaviyoReactNativeSdk : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -14,6 +14,10 @@ RCT_EXPORT_MODULE()
     return YES;
 }
 
+- (NSArray<NSString *> *)supportedEvents {
+    return @[@"FormLifecycleEvent"];
+}
+
 // The values here eventually should come from the iOS SDK once exposed there.
 - (NSDictionary *)constantsToExport {
     return @{
@@ -139,6 +143,24 @@ RCT_EXPORT_METHOD(getCurrentGeofences: (RCTResponseSenderBlock)callback) {
         [KlaviyoBridge getCurrentGeofencesWithCallback:^(NSDictionary *result) {
             callback(@[result]);
         }];
+    });
+}
+
+RCT_EXPORT_METHOD(registerFormLifecycleHandler) {
+    __weak __typeof__(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [KlaviyoBridge registerFormLifecycleHandlerWithCallback:^(NSDictionary *eventData) {
+            __strong __typeof__(weakSelf) strongSelf = weakSelf;
+            if (strongSelf) {
+                [strongSelf sendEventWithName:@"FormLifecycleEvent" body:eventData];
+            }
+        }];
+    });
+}
+
+RCT_EXPORT_METHOD(unregisterFormLifecycleHandler) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [KlaviyoBridge unregisterFormLifecycleHandler];
     });
 }
 

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift" ##, "5.2.2"
+  s.dependency "KlaviyoSwift"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation" ##, "5.2.2"
+    s.dependency "KlaviyoLocation"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms" ##, "5.2.2"
+    s.dependency "KlaviyoForms"
   end
 
   s.default_subspecs = :none

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.2.2"
+  s.dependency "KlaviyoSwift" ##, "5.2.2"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.2.2"
+    s.dependency "KlaviyoLocation" ##, "5.2.2"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.2.2"
+    s.dependency "KlaviyoForms" ##, "5.2.2"
   end
 
   s.default_subspecs = :none

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -34,6 +34,26 @@ export interface FormConfiguration {
 }
 
 /**
+ * String constants for form lifecycle event types.
+ *
+ * These values match the `type` discriminants emitted by the native bridge
+ * and are safe to use when comparing {@link FormLifecycleEvent#type} or
+ * building dispatch tables keyed by event type.
+ */
+export const FormLifecycleEventType = {
+  /** Emitted when a form is shown to the user. */
+  Shown: 'formShown',
+  /** Emitted when the user dismisses a visible form. */
+  Dismissed: 'formDismissed',
+  /** Emitted when the user taps a CTA button with a configured deep link. */
+  CtaClicked: 'formCtaClicked',
+} as const;
+
+/** Union of valid {@link FormLifecycleEvent} type discriminants. */
+export type FormLifecycleEventType =
+  (typeof FormLifecycleEventType)[keyof typeof FormLifecycleEventType];
+
+/**
  * Discriminated union representing a form lifecycle event.
  *
  * Each variant carries contextual data about the form, and the `type` field
@@ -44,13 +64,13 @@ export interface FormConfiguration {
  * ```typescript
  * Klaviyo.registerFormLifecycleHandler((event) => {
  *   switch (event.type) {
- *     case 'formShown':
+ *     case FormLifecycleEventType.Shown:
  *       console.log(`Form shown: ${event.formId}`);
  *       break;
- *     case 'formDismissed':
+ *     case FormLifecycleEventType.Dismissed:
  *       console.log(`Form dismissed: ${event.formId}`);
  *       break;
- *     case 'formCtaClicked':
+ *     case FormLifecycleEventType.CtaClicked:
  *       console.log(`CTA clicked: ${event.buttonLabel}, deep link: ${event.deepLinkUrl}`);
  *       break;
  *   }
@@ -59,23 +79,39 @@ export interface FormConfiguration {
  */
 export type FormLifecycleEvent =
   /** Triggered when a form is shown to the user. Fired after the SDK has initiated form presentation. */
-  | { type: 'formShown'; formId: string; formName: string }
+  | {
+      type: typeof FormLifecycleEventType.Shown;
+      formId: string;
+      formName: string;
+    }
   /**
    * Triggered when a form is dismissed by the user. Fired after the SDK has initiated form dismissal.
    * Fires for user-initiated dismissals (e.g. tapping outside, close button).
    * Does not fire when the SDK tears down the form internally (session timeouts, aborts).
    */
-  | { type: 'formDismissed'; formId: string; formName: string }
+  | {
+      type: typeof FormLifecycleEventType.Dismissed;
+      formId: string;
+      formName: string;
+    }
   /**
    * Triggered when a user taps a call-to-action (CTA) button in a form that has a deep link URL configured.
    * Fired after the SDK has initiated deep link navigation.
    * Not emitted if no deep link URL is configured for the CTA.
    */
   | {
-      type: 'formCtaClicked';
+      type: typeof FormLifecycleEventType.CtaClicked;
       formId: string;
       formName: string;
+      /**
+       * Label of the tapped CTA button. May be an empty string when the
+       * button has no visible label configured.
+       */
       buttonLabel: string;
+      /**
+       * Deep link URL configured for the tapped CTA. Always present and
+       * non-empty — this event is not emitted when no deep link is configured.
+       */
       deepLinkUrl: string;
     };
 
@@ -84,14 +120,8 @@ export type FormLifecycleEvent =
  */
 export type FormLifecycleHandler = (event: FormLifecycleEvent) => void;
 
-/**
- * Valid form lifecycle event type discriminants
- */
-const FORM_LIFECYCLE_EVENT_TYPES = [
-  'formShown',
-  'formDismissed',
-  'formCtaClicked',
-] as const;
+const FORM_LIFECYCLE_EVENT_TYPES: readonly FormLifecycleEventType[] =
+  Object.values(FormLifecycleEventType);
 
 /**
  * Validates that a value is a non-empty string.
@@ -118,9 +148,7 @@ export function parseFormLifecycleEvent(
 
   if (
     !isNonEmptyString(type) ||
-    !FORM_LIFECYCLE_EVENT_TYPES.includes(
-      type as (typeof FORM_LIFECYCLE_EVENT_TYPES)[number]
-    )
+    !FORM_LIFECYCLE_EVENT_TYPES.includes(type as FormLifecycleEventType)
   ) {
     console.warn(
       `[Klaviyo] Ignoring form lifecycle event with invalid type: ${JSON.stringify(type)}`
@@ -132,7 +160,7 @@ export function parseFormLifecycleEvent(
   if (!isNonEmptyString(formId)) missingFields.push('formId');
   if (!isNonEmptyString(formName)) missingFields.push('formName');
 
-  if (type === 'formCtaClicked') {
+  if (type === FormLifecycleEventType.CtaClicked) {
     if (!isNonEmptyString(data.deepLinkUrl)) missingFields.push('deepLinkUrl');
   }
 
@@ -143,24 +171,24 @@ export function parseFormLifecycleEvent(
     return null;
   }
 
-  const validatedType = type as FormLifecycleEvent['type'];
+  const validatedType = type as FormLifecycleEventType;
   const validFormId = formId as string;
   const validFormName = formName as string;
 
   switch (validatedType) {
-    case 'formShown':
+    case FormLifecycleEventType.Shown:
       return {
         type: validatedType,
         formId: validFormId,
         formName: validFormName,
       };
-    case 'formDismissed':
+    case FormLifecycleEventType.Dismissed:
       return {
         type: validatedType,
         formId: validFormId,
         formName: validFormName,
       };
-    case 'formCtaClicked':
+    case FormLifecycleEventType.CtaClicked:
       return {
         type: validatedType,
         formId: validFormId,

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -14,10 +14,17 @@ export interface KlaviyoFormsApi {
    * Unregisters app from receiving in-app forms.
    */
   unregisterFromInAppForms(): void;
+
+  /**
+   * Register a handler to receive form lifecycle events.
+   * @param handler Function to be called when form lifecycle events occur
+   * @returns A function to unsubscribe from lifecycle events
+   */
+  registerFormLifecycleHandler(handler: FormLifecycleHandler): () => void;
 }
 
 /**
- * Interface for an event
+ * Configuration for in-app forms
  */
 export interface FormConfiguration {
   /**
@@ -25,3 +32,43 @@ export interface FormConfiguration {
    */
   readonly sessionTimeoutDuration: number;
 }
+
+/**
+ * Discriminated union representing a form lifecycle event.
+ *
+ * Each variant carries contextual data about the form, and the `type` field
+ * serves as the discriminant. Use a `switch` on `event.type` to narrow the type
+ * and access variant-specific fields like `buttonLabel` and `deepLinkUrl`.
+ *
+ * Example usage:
+ * ```typescript
+ * Klaviyo.registerFormLifecycleHandler((event) => {
+ *   switch (event.type) {
+ *     case 'formShown':
+ *       console.log(`Form shown: ${event.formId}`);
+ *       break;
+ *     case 'formDismissed':
+ *       console.log(`Form dismissed: ${event.formId}`);
+ *       break;
+ *     case 'formCtaClicked':
+ *       console.log(`CTA clicked: ${event.buttonLabel}, deep link: ${event.deepLinkUrl}`);
+ *       break;
+ *   }
+ * });
+ * ```
+ */
+export type FormLifecycleEvent =
+  | { type: 'formShown'; formId: string; formName: string }
+  | { type: 'formDismissed'; formId: string; formName: string }
+  | {
+      type: 'formCtaClicked';
+      formId: string;
+      formName: string;
+      buttonLabel: string;
+      deepLinkUrl: string;
+    };
+
+/**
+ * Handler function type for form lifecycle events
+ */
+export type FormLifecycleHandler = (event: FormLifecycleEvent) => void;

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -58,8 +58,19 @@ export interface FormConfiguration {
  * ```
  */
 export type FormLifecycleEvent =
+  /** Triggered when a form is shown to the user. Fired after the SDK has initiated form presentation. */
   | { type: 'formShown'; formId: string; formName: string }
+  /**
+   * Triggered when a form is dismissed by the user. Fired after the SDK has initiated form dismissal.
+   * Fires for user-initiated dismissals (e.g. tapping outside, close button).
+   * Does not fire when the SDK tears down the form internally (session timeouts, aborts).
+   */
   | { type: 'formDismissed'; formId: string; formName: string }
+  /**
+   * Triggered when a user taps a call-to-action (CTA) button in a form that has a deep link URL configured.
+   * Fired after the SDK has initiated deep link navigation.
+   * Not emitted if no deep link URL is configured for the CTA.
+   */
   | {
       type: 'formCtaClicked';
       formId: string;
@@ -72,3 +83,91 @@ export type FormLifecycleEvent =
  * Handler function type for form lifecycle events
  */
 export type FormLifecycleHandler = (event: FormLifecycleEvent) => void;
+
+/**
+ * Valid form lifecycle event type discriminants
+ */
+const FORM_LIFECYCLE_EVENT_TYPES = [
+  'formShown',
+  'formDismissed',
+  'formCtaClicked',
+] as const;
+
+/**
+ * Validates that a value is a non-empty string.
+ */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Parses a raw native event payload into a validated {@link FormLifecycleEvent}.
+ *
+ * Returns `null` and logs a warning if required fields are missing or empty.
+ * Required fields vary by event type:
+ * - All events: `type`, `formId`, `formName`
+ * - `formCtaClicked`: additionally requires `deepLinkUrl`; `buttonLabel` defaults to empty string if absent
+ *
+ * @param data Raw event data from the native bridge
+ * @returns A validated FormLifecycleEvent, or null if the payload is invalid
+ */
+export function parseFormLifecycleEvent(
+  data: Record<string, unknown>
+): FormLifecycleEvent | null {
+  const { type, formId, formName } = data;
+
+  if (
+    !isNonEmptyString(type) ||
+    !FORM_LIFECYCLE_EVENT_TYPES.includes(
+      type as (typeof FORM_LIFECYCLE_EVENT_TYPES)[number]
+    )
+  ) {
+    console.warn(
+      `[Klaviyo] Ignoring form lifecycle event with invalid type: ${JSON.stringify(type)}`
+    );
+    return null;
+  }
+
+  const missingFields: string[] = [];
+  if (!isNonEmptyString(formId)) missingFields.push('formId');
+  if (!isNonEmptyString(formName)) missingFields.push('formName');
+
+  if (type === 'formCtaClicked') {
+    if (!isNonEmptyString(data.deepLinkUrl)) missingFields.push('deepLinkUrl');
+  }
+
+  if (missingFields.length > 0) {
+    console.warn(
+      `[Klaviyo] Ignoring ${type} event: missing required field(s): ${missingFields.join(', ')}`
+    );
+    return null;
+  }
+
+  const validatedType = type as FormLifecycleEvent['type'];
+  const validFormId = formId as string;
+  const validFormName = formName as string;
+
+  switch (validatedType) {
+    case 'formShown':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+      };
+    case 'formDismissed':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+      };
+    case 'formCtaClicked':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+        buttonLabel:
+          typeof data.buttonLabel === 'string' ? data.buttonLabel : '',
+        deepLinkUrl: data.deepLinkUrl as string,
+      };
+  }
+}

--- a/src/__tests__/Forms.test.ts
+++ b/src/__tests__/Forms.test.ts
@@ -1,0 +1,280 @@
+import { parseFormLifecycleEvent } from '../Forms';
+
+describe('parseFormLifecycleEvent', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('valid events', () => {
+    it('parses a valid formShown event', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toEqual({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('parses a valid formDismissed event', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toEqual({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('parses a valid formCtaClicked event with all fields', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('strips extra fields not part of the event type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        unexpectedField: 'should be ignored',
+      });
+
+      expect(result).toEqual({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+    });
+  });
+
+  describe('invalid type', () => {
+    it('returns null for unknown type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formExploded',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type: "formExploded"')
+      );
+    });
+
+    it('returns null for missing type', () => {
+      const result = parseFormLifecycleEvent({
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+
+    it('returns null for empty string type', () => {
+      const result = parseFormLifecycleEvent({
+        type: '',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+
+    it('returns null for non-string type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 42,
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+  });
+
+  describe('missing required fields', () => {
+    it('returns null when formId is missing', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+    });
+
+    it('returns null when formName is missing', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formName')
+      );
+    });
+
+    it('returns null when formId is empty string', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: '',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId')
+      );
+    });
+
+    it('returns null when formName is empty string', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: '',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formName')
+      );
+    });
+
+    it('defaults missing buttonLabel to empty string for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+    });
+
+    it('allows empty string buttonLabel for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns null when deepLinkUrl is missing for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): deepLinkUrl')
+      );
+    });
+
+    it('returns null when deepLinkUrl is empty string for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: '',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('deepLinkUrl')
+      );
+    });
+
+    it('reports multiple missing fields together', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId, formName, deepLinkUrl')
+      );
+    });
+
+    it('does not require buttonLabel for formShown', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).not.toBeNull();
+    });
+
+    it('does not require buttonLabel for formDismissed', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).not.toBeNull();
+    });
+  });
+});

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -3,6 +3,10 @@ import { Klaviyo } from '../index';
 import { EventName } from '../Event';
 import { ProfileProperty } from '../Profile';
 
+// Store event listeners for testing NativeEventEmitter
+const eventListeners: Record<string, Array<(data: any) => void>> = {};
+const mockRemove = jest.fn();
+
 // Mock the native module
 jest.mock('react-native', () => {
   return {
@@ -24,6 +28,8 @@ jest.mock('react-native', () => {
         createEvent: jest.fn(),
         registerForInAppForms: jest.fn(),
         unregisterFromInAppForms: jest.fn(),
+        registerFormLifecycleHandler: jest.fn(),
+        unregisterFormLifecycleHandler: jest.fn(),
         registerGeofencing: jest.fn(),
         unregisterGeofencing: jest.fn(),
         getCurrentGeofences: jest.fn(),
@@ -61,16 +67,31 @@ jest.mock('react-native', () => {
         }),
       },
     },
+    NativeEventEmitter: jest.fn().mockImplementation(() => ({
+      addListener: jest.fn().mockImplementation((eventName, callback) => {
+        if (!eventListeners[eventName]) {
+          eventListeners[eventName] = [];
+        }
+        eventListeners[eventName]!.push(callback);
+        return { remove: mockRemove };
+      }),
+    })),
     Platform: {
       select: jest.fn().mockImplementation((obj) => obj.ios),
     },
   };
 });
 
+// Helper to simulate native event emission
+function emitNativeEvent(eventName: string, data: any) {
+  eventListeners[eventName]?.forEach((listener) => listener(data));
+}
+
 describe('Klaviyo SDK', () => {
   beforeEach(() => {
-    // Clear all mocks before each test
+    // Clear all mocks and event listeners before each test
     jest.clearAllMocks();
+    Object.keys(eventListeners).forEach((key) => delete eventListeners[key]);
   });
 
   describe('initialization', () => {
@@ -502,6 +523,94 @@ describe('Klaviyo SDK', () => {
 
       // Restore console.error
       consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('form lifecycle events', () => {
+    it('should register native handler and forward formShown events', () => {
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.registerFormLifecycleHandler
+      ).toHaveBeenCalledTimes(1);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+    });
+
+    it('should forward formDismissed events', () => {
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+    });
+
+    it('should forward formCtaClicked events with buttonLabel and deepLinkUrl', () => {
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+    });
+
+    it('should unsubscribe from events when cleanup function is called', () => {
+      const handler = jest.fn();
+      const unsubscribe = Klaviyo.registerFormLifecycleHandler(handler);
+
+      // Clear any remove calls from re-registration cleanup of prior tests
+      mockRemove.mockClear();
+
+      unsubscribe();
+
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clean up previous subscription when re-registering', () => {
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+
+      Klaviyo.registerFormLifecycleHandler(handler1);
+      mockRemove.mockClear();
+
+      // Re-registering should remove the previous listener before adding new one
+      Klaviyo.registerFormLifecycleHandler(handler2);
+      expect(mockRemove).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -623,5 +623,150 @@ describe('Klaviyo SDK', () => {
         NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
       ).toHaveBeenCalledTimes(1);
     });
+
+    it('should not forward events with missing formId', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not forward events with missing formName', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formDismissed',
+        formId: 'abc123',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formName')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not forward events with empty string formId', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formId: '',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should forward formCtaClicked events with missing buttonLabel as empty string', () => {
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+    });
+
+    it('should not forward events with invalid type', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'unknownEventType',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not forward events with missing type', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should report multiple missing fields at once', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formName')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not forward formCtaClicked events with missing deepLinkUrl', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: 'Shop Now',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): deepLinkUrl')
+      );
+      consoleWarnSpy.mockRestore();
+    });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -590,8 +590,12 @@ describe('Klaviyo SDK', () => {
       const handler = jest.fn();
       const unsubscribe = Klaviyo.registerFormLifecycleHandler(handler);
 
-      // Clear any remove calls from re-registration cleanup of prior tests
+      // Clear any calls from re-registration cleanup of prior tests
       mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterFormLifecycleHandler as jest.Mock
+      ).mockClear();
 
       unsubscribe();
 
@@ -607,10 +611,17 @@ describe('Klaviyo SDK', () => {
 
       Klaviyo.registerFormLifecycleHandler(handler1);
       mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterFormLifecycleHandler as jest.Mock
+      ).mockClear();
 
-      // Re-registering should remove the previous listener before adding new one
+      // Re-registering should remove the previous listener and native handler before adding new one
       Klaviyo.registerFormLifecycleHandler(handler2);
       expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
+      ).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,6 +184,7 @@ export {
   ProfileProperty,
 } from './Profile';
 export type { KlaviyoInterface } from './Klaviyo';
+export { FormLifecycleEventType } from './Forms';
 export type {
   FormConfiguration,
   FormLifecycleEvent,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,13 @@ import {
   formatProfile,
 } from './Profile';
 import type { Event } from './Event';
-import type { FormConfiguration } from './Forms';
+import type {
+  FormConfiguration,
+  FormLifecycleHandler,
+  FormLifecycleEvent,
+} from './Forms';
 import type { Geofence } from './Geofencing';
+import { NativeEventEmitter, NativeModules } from 'react-native';
 
 const FORMS_UNAVAILABLE_MESSAGE =
   'Klaviyo In-App Forms is not available. The KlaviyoForms module was not included in this build. ' +
@@ -35,6 +40,9 @@ function isLocationAvailable(): boolean {
   }
   return true;
 }
+
+// Track active lifecycle subscription to prevent duplicate listeners
+let activeLifecycleSubscription: { remove: () => void } | null = null;
 
 /**
  * Implementation of the {@link KlaviyoInterface}
@@ -136,6 +144,41 @@ export const Klaviyo: KlaviyoInterface = {
     KlaviyoReactNativeSdk.handleUniversalTrackingLink(urlStr);
     return true;
   },
+  registerFormLifecycleHandler(handler: FormLifecycleHandler): () => void {
+    if (!isFormsAvailable()) return () => {};
+
+    // Clean up any existing subscription before re-registering
+    if (activeLifecycleSubscription) {
+      activeLifecycleSubscription.remove();
+      KlaviyoReactNativeSdk.unregisterFormLifecycleHandler();
+      activeLifecycleSubscription = null;
+    }
+
+    const eventEmitter = new NativeEventEmitter(
+      NativeModules.KlaviyoReactNativeSdk
+    );
+
+    activeLifecycleSubscription = eventEmitter.addListener(
+      'FormLifecycleEvent',
+      (data: {
+        type: string;
+        formId: string;
+        formName: string;
+        buttonLabel?: string;
+        deepLinkUrl?: string;
+      }) => {
+        handler(data as FormLifecycleEvent);
+      }
+    );
+
+    KlaviyoReactNativeSdk.registerFormLifecycleHandler();
+
+    return () => {
+      activeLifecycleSubscription?.remove();
+      activeLifecycleSubscription = null;
+      KlaviyoReactNativeSdk.unregisterFormLifecycleHandler();
+    };
+  },
 };
 
 export { type Event, type EventProperties, EventName } from './Event';
@@ -147,6 +190,10 @@ export {
   ProfileProperty,
 } from './Profile';
 export type { KlaviyoInterface } from './Klaviyo';
-export type { FormConfiguration } from './Forms';
+export type {
+  FormConfiguration,
+  FormLifecycleEvent,
+  FormLifecycleHandler,
+} from './Forms';
 export type { KlaviyoDeepLinkAPI } from './KlaviyoDeepLinkAPI';
 export type { Geofence } from './Geofencing';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,8 @@ import {
   formatProfile,
 } from './Profile';
 import type { Event } from './Event';
-import type {
-  FormConfiguration,
-  FormLifecycleHandler,
-  FormLifecycleEvent,
-} from './Forms';
+import type { FormConfiguration, FormLifecycleHandler } from './Forms';
+import { parseFormLifecycleEvent } from './Forms';
 import type { Geofence } from './Geofencing';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
@@ -160,14 +157,11 @@ export const Klaviyo: KlaviyoInterface = {
 
     activeLifecycleSubscription = eventEmitter.addListener(
       'FormLifecycleEvent',
-      (data: {
-        type: string;
-        formId: string;
-        formName: string;
-        buttonLabel?: string;
-        deepLinkUrl?: string;
-      }) => {
-        handler(data as FormLifecycleEvent);
+      (data: Record<string, unknown>) => {
+        const event = parseFormLifecycleEvent(data);
+        if (event !== null) {
+          handler(event);
+        }
       }
     );
 


### PR DESCRIPTION
## Summary

Adds form lifecycle event bridging to the React Native SDK, enabling JS consumers to receive callbacks when in-app forms are shown, dismissed, or when a CTA button is clicked.

### Changes

- **New `registerFormLifecycleHandler` API** on the `Klaviyo` object — accepts a `FormLifecycleHandler` callback and returns an unsubscribe function
- **Native bridge on both platforms:**
  - **iOS:** `KlaviyoBridge` registers with the Swift SDK's lifecycle handler and emits `FormLifecycleEvent` via `RCTEventEmitter`; module now extends `RCTEventEmitter` instead of `NSObject`
  - **Android:** Kotlin module registers with the Android SDK's lifecycle handler and emits events via `RCTDeviceEventEmitter`, with `addListener`/`removeListeners` stubs for `NativeEventEmitter` compatibility
- **Re-registration safety** — calling `registerFormLifecycleHandler` again tears down both the JS listener and native handler before re-registering
- **New TypeScript types** — `FormLifecycleEvent` union type (`formShown`, `formDismissed`, `formCtaClicked`) and `FormLifecycleHandler` callback type
- Example app updated to demonstrate lifecycle event logging
- Native SDK dependencies temporarily unpinned for testing against unreleased native SDK builds

### Test plan

- [ ] Unit tests for handler registration, event dispatch, and cleanup
- [ ] Verify lifecycle events bridge correctly on iOS simulator
- [ ] Verify lifecycle events bridge correctly on Android emulator
- [ ] Verify re-registration properly replaces the previous handler
- [ ] Verify unsubscribe function tears down both JS and native listeners

Part of MAGE-287