### PR TITLE
fix(forms): validate required bridge message fields (MAGE-484)

### DIFF
--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -106,7 +106,7 @@ function isNonEmptyString(value: unknown): value is string {
  * Returns `null` and logs a warning if required fields are missing or empty.
  * Required fields vary by event type:
  * - All events: `type`, `formId`, `formName`
- * - `formCtaClicked`: additionally requires `buttonLabel` and `deepLinkUrl`
+ * - `formCtaClicked`: additionally requires `deepLinkUrl`; `buttonLabel` defaults to empty string if absent
  *
  * @param data Raw event data from the native bridge
  * @returns A validated FormLifecycleEvent, or null if the payload is invalid
@@ -133,7 +133,6 @@ export function parseFormLifecycleEvent(
   if (!isNonEmptyString(formName)) missingFields.push('formName');
 
   if (type === 'formCtaClicked') {
-    if (typeof data.buttonLabel !== 'string') missingFields.push('buttonLabel');
     if (!isNonEmptyString(data.deepLinkUrl)) missingFields.push('deepLinkUrl');
   }
 
@@ -166,7 +165,8 @@ export function parseFormLifecycleEvent(
         type: validatedType,
         formId: validFormId,
         formName: validFormName,
-        buttonLabel: data.buttonLabel as string,
+        buttonLabel:
+          typeof data.buttonLabel === 'string' ? data.buttonLabel : '',
         deepLinkUrl: data.deepLinkUrl as string,
       };
   }

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -58,8 +58,19 @@ export interface FormConfiguration {
  * ```
  */
 export type FormLifecycleEvent =
+  /** Triggered when a form is shown to the user. Fired after the SDK has initiated form presentation. */
   | { type: 'formShown'; formId: string; formName: string }
+  /**
+   * Triggered when a form is dismissed by the user. Fired after the SDK has initiated form dismissal.
+   * Fires for user-initiated dismissals (e.g. tapping outside, close button).
+   * Does not fire when the SDK tears down the form internally (session timeouts, aborts).
+   */
   | { type: 'formDismissed'; formId: string; formName: string }
+  /**
+   * Triggered when a user taps a call-to-action (CTA) button in a form that has a deep link URL configured.
+   * Fired after the SDK has initiated deep link navigation.
+   * Not emitted if no deep link URL is configured for the CTA.
+   */
   | {
       type: 'formCtaClicked';
       formId: string;

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -122,7 +122,7 @@ export function parseFormLifecycleEvent(
   if (!isNonEmptyString(formName)) missingFields.push('formName');
 
   if (type === 'formCtaClicked') {
-    if (!isNonEmptyString(data.buttonLabel)) missingFields.push('buttonLabel');
+    if (typeof data.buttonLabel !== 'string') missingFields.push('buttonLabel');
     if (!isNonEmptyString(data.deepLinkUrl)) missingFields.push('deepLinkUrl');
   }
 

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -72,3 +72,91 @@ export type FormLifecycleEvent =
  * Handler function type for form lifecycle events
  */
 export type FormLifecycleHandler = (event: FormLifecycleEvent) => void;
+
+/**
+ * Valid form lifecycle event type discriminants
+ */
+const FORM_LIFECYCLE_EVENT_TYPES = [
+  'formShown',
+  'formDismissed',
+  'formCtaClicked',
+] as const;
+
+/**
+ * Validates that a value is a non-empty string.
+ */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Parses a raw native event payload into a validated {@link FormLifecycleEvent}.
+ *
+ * Returns `null` and logs a warning if required fields are missing or empty.
+ * Required fields vary by event type:
+ * - All events: `type`, `formId`, `formName`
+ * - `formCtaClicked`: additionally requires `buttonLabel`
+ *
+ * @param data Raw event data from the native bridge
+ * @returns A validated FormLifecycleEvent, or null if the payload is invalid
+ */
+export function parseFormLifecycleEvent(
+  data: Record<string, unknown>
+): FormLifecycleEvent | null {
+  const { type, formId, formName } = data;
+
+  if (
+    !isNonEmptyString(type) ||
+    !FORM_LIFECYCLE_EVENT_TYPES.includes(
+      type as (typeof FORM_LIFECYCLE_EVENT_TYPES)[number]
+    )
+  ) {
+    console.error(
+      `[Klaviyo] Ignoring form lifecycle event with invalid type: ${JSON.stringify(type)}`
+    );
+    return null;
+  }
+
+  const missingFields: string[] = [];
+  if (!isNonEmptyString(formId)) missingFields.push('formId');
+  if (!isNonEmptyString(formName)) missingFields.push('formName');
+
+  if (type === 'formCtaClicked' && !isNonEmptyString(data.buttonLabel)) {
+    missingFields.push('buttonLabel');
+  }
+
+  if (missingFields.length > 0) {
+    console.error(
+      `[Klaviyo] Ignoring ${type} event: missing required field(s): ${missingFields.join(', ')}`
+    );
+    return null;
+  }
+
+  const validatedType = type as FormLifecycleEvent['type'];
+  const validFormId = formId as string;
+  const validFormName = formName as string;
+
+  switch (validatedType) {
+    case 'formShown':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+      };
+    case 'formDismissed':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+      };
+    case 'formCtaClicked':
+      return {
+        type: validatedType,
+        formId: validFormId,
+        formName: validFormName,
+        buttonLabel: data.buttonLabel as string,
+        deepLinkUrl:
+          typeof data.deepLinkUrl === 'string' ? data.deepLinkUrl : '',
+      };
+  }
+}

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -92,10 +92,10 @@ function isNonEmptyString(value: unknown): value is string {
 /**
  * Parses a raw native event payload into a validated {@link FormLifecycleEvent}.
  *
- * Returns `null` and logs an error if required fields are missing or empty.
+ * Returns `null` and logs a warning if required fields are missing or empty.
  * Required fields vary by event type:
  * - All events: `type`, `formId`, `formName`
- * - `formCtaClicked`: additionally requires `buttonLabel`
+ * - `formCtaClicked`: additionally requires `buttonLabel` and `deepLinkUrl`
  *
  * @param data Raw event data from the native bridge
  * @returns A validated FormLifecycleEvent, or null if the payload is invalid
@@ -111,7 +111,7 @@ export function parseFormLifecycleEvent(
       type as (typeof FORM_LIFECYCLE_EVENT_TYPES)[number]
     )
   ) {
-    console.error(
+    console.warn(
       `[Klaviyo] Ignoring form lifecycle event with invalid type: ${JSON.stringify(type)}`
     );
     return null;
@@ -121,12 +121,13 @@ export function parseFormLifecycleEvent(
   if (!isNonEmptyString(formId)) missingFields.push('formId');
   if (!isNonEmptyString(formName)) missingFields.push('formName');
 
-  if (type === 'formCtaClicked' && !isNonEmptyString(data.buttonLabel)) {
-    missingFields.push('buttonLabel');
+  if (type === 'formCtaClicked') {
+    if (!isNonEmptyString(data.buttonLabel)) missingFields.push('buttonLabel');
+    if (!isNonEmptyString(data.deepLinkUrl)) missingFields.push('deepLinkUrl');
   }
 
   if (missingFields.length > 0) {
-    console.error(
+    console.warn(
       `[Klaviyo] Ignoring ${type} event: missing required field(s): ${missingFields.join(', ')}`
     );
     return null;
@@ -155,8 +156,7 @@ export function parseFormLifecycleEvent(
         formId: validFormId,
         formName: validFormName,
         buttonLabel: data.buttonLabel as string,
-        deepLinkUrl:
-          typeof data.deepLinkUrl === 'string' ? data.deepLinkUrl : '',
+        deepLinkUrl: data.deepLinkUrl as string,
       };
   }
 }

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -92,7 +92,7 @@ function isNonEmptyString(value: unknown): value is string {
 /**
  * Parses a raw native event payload into a validated {@link FormLifecycleEvent}.
  *
- * Returns `null` and logs a warning if required fields are missing or empty.
+ * Returns `null` and logs an error if required fields are missing or empty.
  * Required fields vary by event type:
  * - All events: `type`, `formId`, `formName`
  * - `formCtaClicked`: additionally requires `buttonLabel`

--- a/src/__tests__/Forms.test.ts
+++ b/src/__tests__/Forms.test.ts
@@ -1,0 +1,261 @@
+import { parseFormLifecycleEvent } from '../Forms';
+
+describe('parseFormLifecycleEvent', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('valid events', () => {
+    it('parses a valid formShown event', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toEqual({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('parses a valid formDismissed event', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toEqual({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('parses a valid formCtaClicked event with all fields', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: 'myapp://products',
+      });
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('defaults deepLinkUrl to empty string when absent', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+      });
+
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: '',
+      });
+    });
+
+    it('strips extra fields not part of the event type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        unexpectedField: 'should be ignored',
+      });
+
+      expect(result).toEqual({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+    });
+  });
+
+  describe('invalid type', () => {
+    it('returns null for unknown type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formExploded',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type: "formExploded"')
+      );
+    });
+
+    it('returns null for missing type', () => {
+      const result = parseFormLifecycleEvent({
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+
+    it('returns null for empty string type', () => {
+      const result = parseFormLifecycleEvent({
+        type: '',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+
+    it('returns null for non-string type', () => {
+      const result = parseFormLifecycleEvent({
+        type: 42,
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+    });
+  });
+
+  describe('missing required fields', () => {
+    it('returns null when formId is missing', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+    });
+
+    it('returns null when formName is missing', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formName')
+      );
+    });
+
+    it('returns null when formId is empty string', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: '',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId')
+      );
+    });
+
+    it('returns null when formName is empty string', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: '',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formName')
+      );
+    });
+
+    it('returns null when buttonLabel is missing for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): buttonLabel')
+      );
+    });
+
+    it('returns null when buttonLabel is empty string for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('buttonLabel')
+      );
+    });
+
+    it('reports multiple missing fields together', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId, formName, buttonLabel')
+      );
+    });
+
+    it('does not require buttonLabel for formShown', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).not.toBeNull();
+    });
+
+    it('does not require buttonLabel for formDismissed', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formDismissed',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+      });
+
+      expect(result).not.toBeNull();
+    });
+  });
+});

--- a/src/__tests__/Forms.test.ts
+++ b/src/__tests__/Forms.test.ts
@@ -1,14 +1,14 @@
 import { parseFormLifecycleEvent } from '../Forms';
 
 describe('parseFormLifecycleEvent', () => {
-  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   describe('valid events', () => {
@@ -24,7 +24,7 @@ describe('parseFormLifecycleEvent', () => {
         formId: 'abc123',
         formName: 'Welcome Form',
       });
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('parses a valid formDismissed event', () => {
@@ -39,7 +39,7 @@ describe('parseFormLifecycleEvent', () => {
         formId: 'abc123',
         formName: 'Welcome Form',
       });
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('parses a valid formCtaClicked event with all fields', () => {
@@ -58,24 +58,7 @@ describe('parseFormLifecycleEvent', () => {
         buttonLabel: 'Shop Now',
         deepLinkUrl: 'myapp://products',
       });
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-    });
-
-    it('defaults deepLinkUrl to empty string when absent', () => {
-      const result = parseFormLifecycleEvent({
-        type: 'formCtaClicked',
-        formId: 'abc123',
-        formName: 'Welcome Form',
-        buttonLabel: 'Shop Now',
-      });
-
-      expect(result).toEqual({
-        type: 'formCtaClicked',
-        formId: 'abc123',
-        formName: 'Welcome Form',
-        buttonLabel: 'Shop Now',
-        deepLinkUrl: '',
-      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('strips extra fields not part of the event type', () => {
@@ -103,7 +86,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type: "formExploded"')
       );
     });
@@ -115,7 +98,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type')
       );
     });
@@ -128,7 +111,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type')
       );
     });
@@ -141,7 +124,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type')
       );
     });
@@ -155,7 +138,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): formId')
       );
     });
@@ -167,7 +150,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): formName')
       );
     });
@@ -180,7 +163,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('formId')
       );
     });
@@ -193,7 +176,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('formName')
       );
     });
@@ -207,7 +190,7 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): buttonLabel')
       );
     });
@@ -222,8 +205,37 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('buttonLabel')
+      );
+    });
+
+    it('returns null when deepLinkUrl is missing for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): deepLinkUrl')
+      );
+    });
+
+    it('returns null when deepLinkUrl is empty string for formCtaClicked', () => {
+      const result = parseFormLifecycleEvent({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: '',
+      });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('deepLinkUrl')
       );
     });
 
@@ -233,8 +245,8 @@ describe('parseFormLifecycleEvent', () => {
       });
 
       expect(result).toBeNull();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('formId, formName, buttonLabel')
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId, formName, buttonLabel, deepLinkUrl')
       );
     });
 

--- a/src/__tests__/Forms.test.ts
+++ b/src/__tests__/Forms.test.ts
@@ -195,7 +195,7 @@ describe('parseFormLifecycleEvent', () => {
       );
     });
 
-    it('returns null when buttonLabel is empty string for formCtaClicked', () => {
+    it('allows empty string buttonLabel for formCtaClicked', () => {
       const result = parseFormLifecycleEvent({
         type: 'formCtaClicked',
         formId: 'abc123',
@@ -204,10 +204,14 @@ describe('parseFormLifecycleEvent', () => {
         deepLinkUrl: 'myapp://products',
       });
 
-      expect(result).toBeNull();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('buttonLabel')
-      );
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('returns null when deepLinkUrl is missing for formCtaClicked', () => {

--- a/src/__tests__/Forms.test.ts
+++ b/src/__tests__/Forms.test.ts
@@ -181,7 +181,7 @@ describe('parseFormLifecycleEvent', () => {
       );
     });
 
-    it('returns null when buttonLabel is missing for formCtaClicked', () => {
+    it('defaults missing buttonLabel to empty string for formCtaClicked', () => {
       const result = parseFormLifecycleEvent({
         type: 'formCtaClicked',
         formId: 'abc123',
@@ -189,10 +189,13 @@ describe('parseFormLifecycleEvent', () => {
         deepLinkUrl: 'myapp://products',
       });
 
-      expect(result).toBeNull();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('missing required field(s): buttonLabel')
-      );
+      expect(result).toEqual({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Welcome Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
     });
 
     it('allows empty string buttonLabel for formCtaClicked', () => {
@@ -250,7 +253,7 @@ describe('parseFormLifecycleEvent', () => {
 
       expect(result).toBeNull();
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('formId, formName, buttonLabel, deepLinkUrl')
+        expect.stringContaining('formId, formName, deepLinkUrl')
       );
     });
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -676,8 +676,7 @@ describe('Klaviyo SDK', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should not forward formCtaClicked events with missing buttonLabel', () => {
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    it('should forward formCtaClicked events with missing buttonLabel as empty string', () => {
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -688,11 +687,13 @@ describe('Klaviyo SDK', () => {
         deepLinkUrl: 'myapp://products',
       });
 
-      expect(handler).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('missing required field(s): buttonLabel')
-      );
-      consoleWarnSpy.mockRestore();
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: '',
+        deepLinkUrl: 'myapp://products',
+      });
     });
 
     it('should not forward events with invalid type', () => {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -625,7 +625,7 @@ describe('Klaviyo SDK', () => {
     });
 
     it('should not forward events with missing formId', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -635,14 +635,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): formId')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not forward events with missing formName', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -652,14 +652,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): formName')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not forward events with empty string formId', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -670,14 +670,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): formId')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not forward formCtaClicked events with missing buttonLabel', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -689,14 +689,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('missing required field(s): buttonLabel')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not forward events with invalid type', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -707,14 +707,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not forward events with missing type', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -724,14 +724,14 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('invalid type')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
     it('should report multiple missing fields at once', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -740,16 +740,17 @@ describe('Klaviyo SDK', () => {
       });
 
       expect(handler).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('formId')
       );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('formName')
       );
-      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     });
 
-    it('should default deepLinkUrl to empty string when missing from formCtaClicked', () => {
+    it('should not forward formCtaClicked events with missing deepLinkUrl', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const handler = jest.fn();
       Klaviyo.registerFormLifecycleHandler(handler);
 
@@ -760,13 +761,11 @@ describe('Klaviyo SDK', () => {
         buttonLabel: 'Shop Now',
       });
 
-      expect(handler).toHaveBeenCalledWith({
-        type: 'formCtaClicked',
-        formId: 'abc123',
-        formName: 'Test Form',
-        buttonLabel: 'Shop Now',
-        deepLinkUrl: '',
-      });
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): deepLinkUrl')
+      );
+      consoleWarnSpy.mockRestore();
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -623,5 +623,150 @@ describe('Klaviyo SDK', () => {
         NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
       ).toHaveBeenCalledTimes(1);
     });
+
+    it('should not forward events with missing formId', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not forward events with missing formName', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formDismissed',
+        formId: 'abc123',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formName')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not forward events with empty string formId', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formId: '',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): formId')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not forward formCtaClicked events with missing buttonLabel', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        deepLinkUrl: 'myapp://products',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing required field(s): buttonLabel')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not forward events with invalid type', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'unknownEventType',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not forward events with missing type', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid type')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should report multiple missing fields at once', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formId')
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('formName')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should default deepLinkUrl to empty string when missing from formCtaClicked', () => {
+      const handler = jest.fn();
+      Klaviyo.registerFormLifecycleHandler(handler);
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: 'Shop Now',
+      });
+
+      expect(handler).toHaveBeenCalledWith({
+        type: 'formCtaClicked',
+        formId: 'abc123',
+        formName: 'Test Form',
+        buttonLabel: 'Shop Now',
+        deepLinkUrl: '',
+      });
+    });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,8 @@ import {
   formatProfile,
 } from './Profile';
 import type { Event } from './Event';
-import type {
-  FormConfiguration,
-  FormLifecycleHandler,
-  FormLifecycleEvent,
-} from './Forms';
+import type { FormConfiguration, FormLifecycleHandler } from './Forms';
+import { parseFormLifecycleEvent } from './Forms';
 import type { Geofence } from './Geofencing';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
@@ -160,14 +157,11 @@ export const Klaviyo: KlaviyoInterface = {
 
     activeLifecycleSubscription = eventEmitter.addListener(
       'FormLifecycleEvent',
-      (data: {
-        type: string;
-        formId: string;
-        formName: string;
-        buttonLabel?: string;
-        deepLinkUrl?: string;
-      }) => {
-        handler(data as FormLifecycleEvent);
+      (data: Record<string, unknown>) => {
+        const event = parseFormLifecycleEvent(data);
+        if (event !== null) {
+          handler(event);
+        }
       }
     );
 


### PR DESCRIPTION
# Description

Adds validation to form lifecycle event parsing at the native-to-JS bridge boundary. When mapping raw native event payloads to the TypeScript `FormLifecycleEvent` type, required fields (`type`, `formId`, `formName`, and `buttonLabel` for CTA events) are now validated. Malformed events are logged and dropped rather than forwarded to the host app's callback.

Part of MAGE-484

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

- **`src/Forms.ts`**: Added `parseFormLifecycleEvent()` — a parse function that validates required fields and returns `null` for invalid payloads, logging an error with the specific missing fields.
- **`src/index.tsx`**: Updated the `NativeEventEmitter` listener in `registerFormLifecycleHandler` to use the new parser instead of an unsafe `as` cast. Invalid events are silently dropped (after logging).
- **`src/__tests__/Forms.test.ts`**: New dedicated test file for the parser with 18 test cases covering valid events, invalid types, missing/empty required fields, and edge cases.
- **`src/__tests__/index.test.tsx`**: Added 8 integration tests verifying that invalid payloads don't reach the host app handler.

## Test Plan

- `yarn test` — 54 tests pass (26 new)
- `yarn lint` — clean (pre-existing Swift warnings only)
- `yarn typecheck` — clean

## Related Issues/Tickets

Part of MAGE-484