### PR TITLE
feat(example): subscribe to form lifecycle events with debug modal

### DIFF
--- a/example/src/components/FormLifecycleEventsModal.tsx
+++ b/example/src/components/FormLifecycleEventsModal.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { FormLifecycleEventType } from 'klaviyo-react-native-sdk';
+import { colors, spacing, borderRadius, typography } from '../theme';
+import type { FormLifecycleLogEntry } from '../hooks/useForms';
+
+interface FormLifecycleEventsModalProps {
+  visible: boolean;
+  events: FormLifecycleLogEntry[];
+  onClose: () => void;
+  onClear: () => void;
+}
+
+const eventLabel = (type: FormLifecycleEventType): string => {
+  switch (type) {
+    case FormLifecycleEventType.Shown:
+      return 'Shown';
+    case FormLifecycleEventType.Dismissed:
+      return 'Dismissed';
+    case FormLifecycleEventType.CtaClicked:
+      return 'CTA Clicked';
+  }
+};
+
+const formatTimestamp = (ms: number): string => {
+  const d = new Date(ms);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${d
+    .getMilliseconds()
+    .toString()
+    .padStart(3, '0')}`;
+};
+
+export const FormLifecycleEventsModal: React.FC<
+  FormLifecycleEventsModalProps
+> = ({ visible, events, onClose, onClear }) => {
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={true}
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>
+            {`Form Lifecycle Events (${events.length})`}
+          </Text>
+          {events.length === 0 ? (
+            <Text style={styles.emptyText}>
+              No form lifecycle events received yet. Register for in-app forms
+              and trigger one in your Klaviyo account.
+            </Text>
+          ) : (
+            <FlatList<FormLifecycleLogEntry>
+              data={events}
+              keyExtractor={(item) => String(item.id)}
+              renderItem={({ item }) => {
+                const { event, receivedAt } = item;
+                return (
+                  <View style={styles.eventItem}>
+                    <View style={styles.eventHeader}>
+                      <Text style={styles.eventType}>
+                        {eventLabel(event.type)}
+                      </Text>
+                      <Text style={styles.eventTime}>
+                        {formatTimestamp(receivedAt)}
+                      </Text>
+                    </View>
+                    {/* Values are JSON.stringify'd so the modal functions as a
+                        protocol inspector — empty strings render as "" instead
+                        of being collapsed into placeholder text. */}
+                    <Text
+                      style={styles.eventDetail}
+                    >{`formId: ${JSON.stringify(event.formId)}`}</Text>
+                    <Text
+                      style={styles.eventDetail}
+                    >{`formName: ${JSON.stringify(event.formName)}`}</Text>
+                    {event.type === FormLifecycleEventType.CtaClicked && (
+                      <>
+                        <Text
+                          style={styles.eventDetail}
+                        >{`buttonLabel: ${JSON.stringify(event.buttonLabel)}`}</Text>
+                        <Text
+                          style={styles.eventDetail}
+                        >{`deepLinkUrl: ${JSON.stringify(event.deepLinkUrl)}`}</Text>
+                      </>
+                    )}
+                  </View>
+                );
+              }}
+            />
+          )}
+          <View style={styles.buttonRow}>
+            <TouchableOpacity
+              style={[styles.button, styles.clearButton]}
+              onPress={onClear}
+              disabled={events.length === 0}
+            >
+              <Text
+                style={[
+                  styles.buttonText,
+                  events.length === 0 && styles.buttonTextDisabled,
+                ]}
+              >
+                Clear
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.button, styles.closeButton]}
+              onPress={onClose}
+            >
+              <Text style={styles.buttonText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.mdlg,
+  },
+  container: {
+    backgroundColor: colors.cardBackground,
+    borderRadius: borderRadius.md,
+    padding: spacing.mdlg,
+    width: '100%',
+    maxHeight: '80%',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600' as const,
+    color: colors.text,
+    marginBottom: spacing.md,
+    textAlign: 'center' as const,
+  },
+  emptyText: {
+    ...typography.label,
+    color: colors.secondaryText,
+    textAlign: 'center' as const,
+    marginBottom: spacing.md,
+    fontStyle: 'italic' as const,
+  },
+  eventItem: {
+    paddingVertical: spacing.smmd,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  eventHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 2,
+  },
+  eventType: {
+    ...typography.label,
+    fontWeight: '600' as const,
+    color: colors.text,
+  },
+  eventTime: {
+    fontSize: 12,
+    color: colors.secondaryText,
+    fontFamily: 'monospace',
+  },
+  eventDetail: {
+    fontSize: 12,
+    color: colors.secondaryText,
+    fontFamily: 'monospace',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    marginTop: spacing.md,
+    gap: spacing.sm,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: spacing.smmd,
+    borderRadius: borderRadius.sm,
+    alignItems: 'center' as const,
+  },
+  clearButton: {
+    backgroundColor: colors.border,
+  },
+  closeButton: {
+    backgroundColor: colors.primary,
+  },
+  buttonText: {
+    ...typography.button,
+    color: colors.buttonText,
+  },
+  buttonTextDisabled: {
+    opacity: 0.5,
+  },
+});

--- a/example/src/hooks/useForms.ts
+++ b/example/src/hooks/useForms.ts
@@ -1,9 +1,50 @@
-import { useState } from 'react';
-import { Klaviyo } from 'klaviyo-react-native-sdk';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Klaviyo, type FormLifecycleEvent } from 'klaviyo-react-native-sdk';
+
+// A received event plus a monotonic id and wall-clock time, used by the
+// FormLifecycleEventsModal to render a chronological log. The id is assigned
+// at insertion so FlatList keys stay stable across prepends.
+export type FormLifecycleLogEntry = {
+  id: number;
+  receivedAt: number;
+  event: FormLifecycleEvent;
+};
+
+// Ring-buffer cap — new entries push oldest out once we hit this many.
+const MAX_LIFECYCLE_EVENTS = 100;
 
 export function useForms() {
   // Registered state always starts false — set to true only after a successful register call.
   const [formsRegistered, setFormsRegistered] = useState(false);
+
+  // Lifecycle event log — newest first, capped at MAX_LIFECYCLE_EVENTS.
+  const [lifecycleEvents, setLifecycleEvents] = useState<
+    FormLifecycleLogEntry[]
+  >([]);
+  const [eventsModalVisible, setEventsModalVisible] = useState(false);
+  const nextEventIdRef = useRef(0);
+
+  // Subscribe to form lifecycle events for the lifetime of the hook. The SDK
+  // only emits events while forms are registered, so subscribing unconditionally
+  // is safe — the handler is idle until `registerForInAppForms` is called.
+  // registerFormLifecycleHandler returns an unsubscribe function.
+  useEffect(() => {
+    console.log('[useForms] subscribing to form lifecycle events');
+    const unsubscribe = Klaviyo.registerFormLifecycleHandler((event) => {
+      console.log('[useForms] lifecycle event:', event);
+      const id = ++nextEventIdRef.current;
+      setLifecycleEvents((prev) =>
+        [{ id, receivedAt: Date.now(), event }, ...prev].slice(
+          0,
+          MAX_LIFECYCLE_EVENTS
+        )
+      );
+    });
+    return () => {
+      console.log('[useForms] unsubscribing from form lifecycle events');
+      unsubscribe();
+    };
+  }, []);
 
   const handleRegisterForms = () => {
     // Passed explicitly here to demonstrate the FormConfiguration shape;
@@ -21,9 +62,26 @@ export function useForms() {
     console.log('[useForms] registered → false');
   };
 
+  const handleShowEventsModal = useCallback(() => {
+    setEventsModalVisible(true);
+  }, []);
+
+  const handleCloseEventsModal = useCallback(() => {
+    setEventsModalVisible(false);
+  }, []);
+
+  const handleClearEvents = useCallback(() => {
+    setLifecycleEvents([]);
+  }, []);
+
   return {
     formsRegistered,
     handleRegisterForms,
     handleUnregisterForms,
+    lifecycleEvents,
+    eventsModalVisible,
+    handleShowEventsModal,
+    handleCloseEventsModal,
+    handleClearEvents,
   };
 }

--- a/example/src/sections/FormsSection.tsx
+++ b/example/src/sections/FormsSection.tsx
@@ -2,6 +2,8 @@ import { View } from 'react-native';
 
 import { useForms } from '../hooks/useForms';
 import { styles } from '../Styles';
+import { ActionButton } from '../components/ActionButton';
+import { FormLifecycleEventsModal } from '../components/FormLifecycleEventsModal';
 import { ToggleButtons } from '../components/ToggleButtons';
 
 export function FormsSection() {
@@ -17,6 +19,17 @@ export function FormsSection() {
         onRightPress={forms.handleUnregisterForms}
         leftDisabled={forms.formsRegistered}
         rightDisabled={!forms.formsRegistered}
+      />
+      <ActionButton
+        title={`Show Lifecycle Events (${forms.lifecycleEvents.length})`}
+        onPress={forms.handleShowEventsModal}
+        withTopSpacing
+      />
+      <FormLifecycleEventsModal
+        visible={forms.eventsModalVisible}
+        events={forms.lifecycleEvents}
+        onClose={forms.handleCloseEventsModal}
+        onClear={forms.handleClearEvents}
       />
     </View>
   );


### PR DESCRIPTION
# Description

Part 4 of 4 in the RN example-app overhaul chain for [MAGE-464](https://linear.app/klaviyo/issue/MAGE-464). Adds a live event log for `Klaviyo.registerFormLifecycleHandler` — the new API introduced in RN SDK 2.4.0 — so integrators have a working reference implementation and a built-in protocol inspector for their QA sessions.

**Stacked on #345** (`ecm/example-app/4-native`). This PR should be rebased onto `feat/example-app` (or master, whichever is the eventual landing target) once #345 merges; the diff shown here is only the delta on top of that base.

### What changed

- **`useForms`** — subscribes to `registerFormLifecycleHandler` on mount (no toggle needed; SDK only emits while forms are registered). Stores events in a ring-buffer (FIFO, capped at 100) so a long QA session doesn't pin an ever-growing array.
- **`FormLifecycleEventsModal`** (new) — mirrors the `GeofencesModal` structure. Renders a `FlatList` with per-event timestamps, `formId`/`formName`, event type badge, and `buttonLabel`/`deepLinkUrl` for CTA-click events. Keys are a monotonic id assigned at insertion for stable FlatList reconciler reuse across prepends. Detail fields use `JSON.stringify` so the modal functions as a protocol inspector — `buttonLabel: ""` renders as `""` rather than collapsing (the SDK documents empty-string as a valid value).
- **`FormsSection`** — new `ActionButton` showing a live count of captured events that opens the modal.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable). _(JS-only change; no platform split.)_

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.

> Example app only — no public API changes, no version bump needed.

## Changelog / Code Overview

| File | Change |
|------|--------|
| `example/src/hooks/useForms.ts` | Subscribe to lifecycle handler on mount; maintain ring-buffer event state; return event array + clear fn |
| `example/src/components/FormLifecycleEventsModal.tsx` | New modal component — chronological event log with type badge, timestamps, and detail inspector |
| `example/src/sections/FormsSection.tsx` | New ActionButton wiring event count → modal |

## Test Plan

Here's how it looks
<img width="320" height="213" alt="Screenshot 2026-04-21 at 5 06 57 PM" src="https://github.com/user-attachments/assets/102d6396-4fe3-4b68-9499-3432bd6aa926" />
<img width="354" height="765" alt="Screenshot 2026-04-21 at 5 06 46 PM" src="https://github.com/user-attachments/assets/c043f6df-b027-48e5-91c9-8c4b9bb6f2f3" />


- [ ] iOS: trigger a form show event — confirm it appears in the modal with correct `formId`, `formName`, and timestamp
- [ ] iOS: trigger a form dismiss — confirm `dismissed` event type badge appears
- [ ] iOS: trigger a form CTA click — confirm `buttonLabel` and `deepLinkUrl` are rendered (not collapsed), including when `buttonLabel` is an empty string
- [ ] iOS: generate >100 events — confirm older entries are evicted (ring-buffer, not unbounded growth)
- [ ] Android: repeat the above — same behavior expected (JS-only change)
- [ ] Confirm Clear button resets the list and the count badge on `FormsSection` goes to 0
- [ ] Confirm app cold-starts cleanly with no forms registered — no crash, event count shows 0

## Related Issues/Tickets

Part of [MAGE-464](https://linear.app/klaviyo/issue/MAGE-464)

**Chained PR series:**
1. theme + components (merged in #342)
2. JS layer: permission helpers, hooks, app shell (merged in #343)
3. native platform setup — #345
4. **This PR** — lifecycle event subscription + debug modal
5. docs — #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)