### PR TITLE
feat(example): allow setting and persisting Company ID at runtime

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+excluded:
+  - '**/node_modules'
+  - '**/Pods'
+
+disabled_rules:
+  # Arbitrary 250-line class body limit; we'll judge complexity by other means.
+  - type_body_length

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		ECAD002C2BC0AD0100000001 /* KlaviyoReactNativeSdkExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD002D2BC0AD0100000002 /* KlaviyoReactNativeSdkExampleTests.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		1BE92CB23FB415E631030426 /* Pods_KlaviyoReactNativeSdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEC94C900FFF3B8C61C8D2B9 /* Pods_KlaviyoReactNativeSdkExample.framework */; };
 		346E4F992BC59CB200CBCFC1 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346E4F982BC59CB200CBCFC1 /* NotificationService.swift */; };
@@ -18,6 +17,7 @@
 		858546827EE31BCF954B5894 /* Pods_KlaviyoReactNativeSdkExample_KlaviyoReactNativeSdkExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2EAF4C8777D1D9603852AFE9 /* Pods_KlaviyoReactNativeSdkExample_KlaviyoReactNativeSdkExampleTests.framework */; };
 		DECD2DBA06E2DAA45E7CDF3E /* Pods_KlaviyoReactNativeSdkExampleExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17427A3A2BF01B069BB68B44 /* Pods_KlaviyoReactNativeSdkExampleExtension.framework */; };
 		ECAD001C2BC0AD0100000001 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD001D2BC0AD0100000002 /* AppDelegate.swift */; };
+		ECAD002C2BC0AD0100000001 /* KlaviyoReactNativeSdkExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD002D2BC0AD0100000002 /* KlaviyoReactNativeSdkExampleTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,7 +54,6 @@
 /* Begin PBXFileReference section */
 		00E356EE1AD99517003FC87E /* KlaviyoReactNativeSdkExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KlaviyoReactNativeSdkExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		ECAD002D2BC0AD0100000002 /* KlaviyoReactNativeSdkExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlaviyoReactNativeSdkExampleTests.swift; sourceTree = "<group>"; };
 		02D376B6B2241AD5D0F0527E /* Pods-KlaviyoReactNativeSdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KlaviyoReactNativeSdkExample.debug.xcconfig"; path = "Target Support Files/Pods-KlaviyoReactNativeSdkExample/Pods-KlaviyoReactNativeSdkExample.debug.xcconfig"; sourceTree = "<group>"; };
 		0ECD08CB82CD21CD0799D483 /* Pods-KlaviyoReactNativeSdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KlaviyoReactNativeSdkExample.release.xcconfig"; path = "Target Support Files/Pods-KlaviyoReactNativeSdkExample/Pods-KlaviyoReactNativeSdkExample.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* KlaviyoReactNativeSdkExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KlaviyoReactNativeSdkExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -74,6 +73,7 @@
 		974C3532D83C254EB74322A0 /* Pods-KlaviyoReactNativeSdkExampleExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KlaviyoReactNativeSdkExampleExtension.release.xcconfig"; path = "Target Support Files/Pods-KlaviyoReactNativeSdkExampleExtension/Pods-KlaviyoReactNativeSdkExampleExtension.release.xcconfig"; sourceTree = "<group>"; };
 		E4C158056E6A2B2F8545C7E8 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = KlaviyoReactNativeSdkExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ECAD001D2BC0AD0100000002 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = KlaviyoReactNativeSdkExample/AppDelegate.swift; sourceTree = "<group>"; };
+		ECAD002D2BC0AD0100000002 /* KlaviyoReactNativeSdkExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlaviyoReactNativeSdkExampleTests.swift; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		EEC94C900FFF3B8C61C8D2B9 /* Pods_KlaviyoReactNativeSdkExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KlaviyoReactNativeSdkExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD53FFCC5B84A56D4578F6AF /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2416,6 +2416,34 @@ PODS:
     - React-perflogger (= 0.81.5)
     - React-utils (= 0.81.5)
     - SocketRocket
+  - RNCAsyncStorage (2.2.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNFBApp (24.0.0):
     - boost
     - DoubleConversion
@@ -2586,6 +2614,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -2766,6 +2795,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBMessaging:
@@ -2878,6 +2909,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c277c5b231881ad4f00cd59e3aa0671b99d7ebee
   ReactCodegen: 1e847cf77c1402fe7394dae41b3829c95569e76e
   ReactCommon: 5cfd842fcd893bb40fc835f98fadc60c42906a20
+  RNCAsyncStorage: 8857fb173af29664cb90897903902dc8533e36cc
   RNFBApp: 60f4af1a2a4d35178aa4faccf1dbba6792ad0ece
   RNFBMessaging: 55269ab548e741b512386230d5d3856b3e963584
   RNPermissions: 86933bcc014e7fa7d77e09b7b0b0b858287d611f

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "build:ios": "react-native build-ios --scheme KlaviyoReactNativeSdkExample --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\""
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-native-firebase/app": "^24.0.0",
     "@react-native-firebase/messaging": "^24.0.0",
     "@react-native/new-app-screen": "0.81.5",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 // React / React Native
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { SectionList, SafeAreaView, Linking } from 'react-native';
 
 // Klaviyo SDK
@@ -8,6 +8,9 @@ import { Klaviyo } from 'klaviyo-react-native-sdk';
 // Local components / styles
 import { styles } from './Styles';
 import { SectionHeader } from './components/SectionHeader';
+import { AppHeader } from './components/AppHeader';
+import { CompanyIdModal } from './components/CompanyIdModal';
+import { useCompanyId } from './hooks/useCompanyId';
 
 // Section components — each section owns the hook(s) it consumes, so state
 // changes in one section don't re-render sibling sections. No React.memo or
@@ -69,6 +72,10 @@ const renderSection = (sectionKey: SectionKey) => {
 };
 
 export default function App() {
+  const { companyId, isOverridden, changeCompanyId, resetToDefault } =
+    useCompanyId();
+  const [settingsVisible, setSettingsVisible] = useState(false);
+
   useEffect(() => {
     // Deep linking handler
     const handleUrl = (url: string) => {
@@ -97,6 +104,7 @@ export default function App() {
 
   return (
     <SafeAreaView style={styles.container}>
+      <AppHeader onSettingsPress={() => setSettingsVisible(true)} />
       <SectionList
         style={styles.container}
         contentContainerStyle={styles.scrollContent}
@@ -107,6 +115,20 @@ export default function App() {
           <SectionHeader title={section.title} />
         )}
         stickySectionHeadersEnabled={false}
+      />
+      <CompanyIdModal
+        visible={settingsVisible}
+        currentCompanyId={companyId}
+        isOverridden={isOverridden}
+        onSave={(key) => {
+          changeCompanyId(key);
+          setSettingsVisible(false);
+        }}
+        onReset={() => {
+          resetToDefault();
+          setSettingsVisible(false);
+        }}
+        onClose={() => setSettingsVisible(false)}
       />
     </SafeAreaView>
   );

--- a/example/src/components/AppHeader.tsx
+++ b/example/src/components/AppHeader.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors, spacing, typography } from '../theme';
+
+interface AppHeaderProps {
+  onSettingsPress: () => void;
+}
+
+export const AppHeader: React.FC<AppHeaderProps> = ({ onSettingsPress }) => {
+  return (
+    <View style={styles.header}>
+      <Text style={styles.title}>Klaviyo SDK Example</Text>
+      <TouchableOpacity
+        onPress={onSettingsPress}
+        style={styles.settingsButton}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityLabel="Open settings"
+        accessibilityRole="button"
+      >
+        <Text style={styles.settingsIcon}>⚙</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.smmd,
+    backgroundColor: colors.cardBackground,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  title: {
+    ...typography.sectionHeader,
+    color: colors.text,
+  },
+  settingsButton: {
+    padding: spacing.xs,
+  },
+  settingsIcon: {
+    fontSize: 22,
+    color: colors.secondaryText,
+  },
+});

--- a/example/src/components/BaseModal.tsx
+++ b/example/src/components/BaseModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Modal, View, Text, StyleSheet, type ViewStyle } from 'react-native';
+import { colors, spacing, borderRadius } from '../theme';
+
+interface BaseModalProps {
+  visible: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  // Cap on container height — pass when content can grow (lists). Omit for
+  // content-sized modals.
+  maxHeight?: ViewStyle['maxHeight'];
+}
+
+/**
+ * Shared modal shell: dimmed overlay, centered card container, centered title.
+ * `statusBarTranslucent` ensures the scrim covers the Android notch area —
+ * without it, the system status bar leaves an unscrim'd band at the top.
+ */
+export const BaseModal: React.FC<BaseModalProps> = ({
+  visible,
+  onClose,
+  title,
+  children,
+  maxHeight,
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={true}
+      statusBarTranslucent={true}
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View
+          style={[styles.container, maxHeight !== undefined && { maxHeight }]}
+        >
+          <Text style={styles.title}>{title}</Text>
+          {children}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: colors.modalOverlay,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.mdlg,
+  },
+  container: {
+    backgroundColor: colors.cardBackground,
+    borderRadius: borderRadius.md,
+    padding: spacing.mdlg,
+    width: '100%',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600' as const,
+    color: colors.text,
+    marginBottom: spacing.md,
+    textAlign: 'center' as const,
+  },
+});

--- a/example/src/components/CompanyIdModal.tsx
+++ b/example/src/components/CompanyIdModal.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { DEFAULT_COMPANY_ID } from '../hooks/useCompanyId';
+import { colors, spacing, borderRadius, typography } from '../theme';
+
+interface CompanyIdModalProps {
+  visible: boolean;
+  currentCompanyId: string;
+  isOverridden: boolean;
+  onSave: (newKey: string) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+export const CompanyIdModal: React.FC<CompanyIdModalProps> = ({
+  visible,
+  currentCompanyId,
+  isOverridden,
+  onSave,
+  onReset,
+  onClose,
+}) => {
+  const [draft, setDraft] = useState('');
+
+  // Reset draft each time the modal opens
+  useEffect(() => {
+    if (visible) {
+      setDraft('');
+    }
+  }, [visible]);
+
+  const trimmed = draft.trim();
+  const canSave = trimmed.length > 0 && trimmed !== currentCompanyId;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent={true}
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>Company ID</Text>
+
+          <Text style={styles.label}>Active</Text>
+          <Text style={styles.currentKey}>{currentCompanyId}</Text>
+          {isOverridden && (
+            <Text style={styles.defaultHint}>
+              {`Default: ${DEFAULT_COMPANY_ID}`}
+            </Text>
+          )}
+
+          <Text style={[styles.label, { marginTop: spacing.md }]}>
+            Change Company ID
+          </Text>
+          <TextInput
+            style={styles.input}
+            value={draft}
+            onChangeText={setDraft}
+            placeholder={currentCompanyId}
+            placeholderTextColor={colors.placeholderText}
+            autoCapitalize="none"
+            autoCorrect={false}
+            returnKeyType="done"
+            onSubmitEditing={() => canSave && onSave(trimmed)}
+          />
+
+          <View style={styles.buttonRow}>
+            <TouchableOpacity
+              style={[styles.button, styles.cancelButton]}
+              onPress={onClose}
+            >
+              <Text style={styles.cancelButtonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                styles.button,
+                styles.saveButton,
+                !canSave && styles.saveButtonDisabled,
+              ]}
+              onPress={() => canSave && onSave(trimmed)}
+              disabled={!canSave}
+            >
+              <Text
+                style={[
+                  styles.saveButtonText,
+                  !canSave && styles.saveButtonTextDisabled,
+                ]}
+              >
+                Save
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {isOverridden && (
+            <TouchableOpacity
+              style={[styles.button, styles.resetButton]}
+              onPress={onReset}
+            >
+              <Text style={styles.resetButtonText}>Reset to Default</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.mdlg,
+  },
+  container: {
+    backgroundColor: colors.cardBackground,
+    borderRadius: borderRadius.md,
+    padding: spacing.mdlg,
+    width: '100%',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600' as const,
+    color: colors.text,
+    marginBottom: spacing.md,
+    textAlign: 'center' as const,
+  },
+  label: {
+    ...typography.label,
+    color: colors.secondaryText,
+    marginBottom: spacing.xs,
+  },
+  currentKey: {
+    ...typography.body,
+    color: colors.text,
+    fontFamily: 'monospace',
+    backgroundColor: colors.disabledBackground,
+    borderRadius: borderRadius.sm,
+    padding: spacing.smmd,
+    overflow: 'hidden' as const,
+  },
+  defaultHint: {
+    ...typography.label,
+    color: colors.secondaryText,
+    fontFamily: 'monospace',
+    marginTop: spacing.xs,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.sm,
+    padding: spacing.smmd,
+    ...typography.body,
+    color: colors.text,
+    backgroundColor: colors.cardBackground,
+    minHeight: 44,
+    fontFamily: 'monospace',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    marginTop: spacing.md,
+    gap: spacing.sm,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: spacing.smmd,
+    borderRadius: borderRadius.sm,
+    alignItems: 'center' as const,
+    minHeight: 44,
+    justifyContent: 'center' as const,
+  },
+  cancelButton: {
+    backgroundColor: colors.disabledBackground,
+  },
+  cancelButtonText: {
+    ...typography.button,
+    color: colors.text,
+  },
+  saveButton: {
+    backgroundColor: colors.primary,
+  },
+  saveButtonDisabled: {
+    backgroundColor: colors.disabled,
+    opacity: 0.5,
+  },
+  saveButtonText: {
+    ...typography.button,
+    color: colors.buttonText,
+  },
+  saveButtonTextDisabled: {
+    color: colors.buttonText,
+  },
+  resetButton: {
+    marginTop: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.destructive,
+    backgroundColor: colors.cardBackground,
+  },
+  resetButtonText: {
+    ...typography.button,
+    color: colors.destructive,
+  },
+});

--- a/example/src/components/CompanyIdModal.tsx
+++ b/example/src/components/CompanyIdModal.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Modal,
   View,
   Text,
   TextInput,
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
+import { BaseModal } from './BaseModal';
 import { DEFAULT_COMPANY_ID } from '../hooks/useCompanyId';
 import { colors, spacing, borderRadius, typography } from '../theme';
 
@@ -29,7 +29,6 @@ export const CompanyIdModal: React.FC<CompanyIdModalProps> = ({
 }) => {
   const [draft, setDraft] = useState('');
 
-  // Reset draft each time the modal opens
   useEffect(() => {
     if (visible) {
       setDraft('');
@@ -40,101 +39,70 @@ export const CompanyIdModal: React.FC<CompanyIdModalProps> = ({
   const canSave = trimmed.length > 0 && trimmed !== currentCompanyId;
 
   return (
-    <Modal
-      visible={visible}
-      animationType="slide"
-      transparent={true}
-      onRequestClose={onClose}
-    >
-      <View style={styles.overlay}>
-        <View style={styles.container}>
-          <Text style={styles.title}>Company ID</Text>
+    <BaseModal visible={visible} onClose={onClose} title="Company ID">
+      <Text style={styles.label}>Active</Text>
+      <Text style={styles.currentKey}>{currentCompanyId}</Text>
+      {isOverridden && (
+        <Text style={styles.defaultHint}>
+          {`Default: ${DEFAULT_COMPANY_ID}`}
+        </Text>
+      )}
 
-          <Text style={styles.label}>Active</Text>
-          <Text style={styles.currentKey}>{currentCompanyId}</Text>
-          {isOverridden && (
-            <Text style={styles.defaultHint}>
-              {`Default: ${DEFAULT_COMPANY_ID}`}
-            </Text>
-          )}
+      <Text style={[styles.label, { marginTop: spacing.md }]}>
+        Change Company ID
+      </Text>
+      <TextInput
+        style={styles.input}
+        value={draft}
+        onChangeText={setDraft}
+        placeholder={currentCompanyId}
+        placeholderTextColor={colors.placeholderText}
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="done"
+        onSubmitEditing={() => canSave && onSave(trimmed)}
+      />
 
-          <Text style={[styles.label, { marginTop: spacing.md }]}>
-            Change Company ID
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.button, styles.cancelButton]}
+          onPress={onClose}
+        >
+          <Text style={styles.cancelButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[
+            styles.button,
+            styles.saveButton,
+            !canSave && styles.saveButtonDisabled,
+          ]}
+          onPress={() => canSave && onSave(trimmed)}
+          disabled={!canSave}
+        >
+          <Text
+            style={[
+              styles.saveButtonText,
+              !canSave && styles.saveButtonTextDisabled,
+            ]}
+          >
+            Save
           </Text>
-          <TextInput
-            style={styles.input}
-            value={draft}
-            onChangeText={setDraft}
-            placeholder={currentCompanyId}
-            placeholderTextColor={colors.placeholderText}
-            autoCapitalize="none"
-            autoCorrect={false}
-            returnKeyType="done"
-            onSubmitEditing={() => canSave && onSave(trimmed)}
-          />
-
-          <View style={styles.buttonRow}>
-            <TouchableOpacity
-              style={[styles.button, styles.cancelButton]}
-              onPress={onClose}
-            >
-              <Text style={styles.cancelButtonText}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                styles.saveButton,
-                !canSave && styles.saveButtonDisabled,
-              ]}
-              onPress={() => canSave && onSave(trimmed)}
-              disabled={!canSave}
-            >
-              <Text
-                style={[
-                  styles.saveButtonText,
-                  !canSave && styles.saveButtonTextDisabled,
-                ]}
-              >
-                Save
-              </Text>
-            </TouchableOpacity>
-          </View>
-
-          {isOverridden && (
-            <TouchableOpacity
-              style={[styles.button, styles.resetButton]}
-              onPress={onReset}
-            >
-              <Text style={styles.resetButtonText}>Reset to Default</Text>
-            </TouchableOpacity>
-          )}
-        </View>
+        </TouchableOpacity>
       </View>
-    </Modal>
+
+      {isOverridden && (
+        <TouchableOpacity
+          style={[styles.button, styles.resetButton]}
+          onPress={onReset}
+        >
+          <Text style={styles.resetButtonText}>Reset to Default</Text>
+        </TouchableOpacity>
+      )}
+    </BaseModal>
   );
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.mdlg,
-  },
-  container: {
-    backgroundColor: colors.cardBackground,
-    borderRadius: borderRadius.md,
-    padding: spacing.mdlg,
-    width: '100%',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: '600' as const,
-    color: colors.text,
-    marginBottom: spacing.md,
-    textAlign: 'center' as const,
-  },
   label: {
     ...typography.label,
     color: colors.secondaryText,
@@ -202,6 +170,7 @@ const styles = StyleSheet.create({
   },
   resetButton: {
     marginTop: spacing.sm,
+    marginBottom: spacing.md,
     borderWidth: 1,
     borderColor: colors.destructive,
     backgroundColor: colors.cardBackground,

--- a/example/src/components/FormLifecycleEventsModal.tsx
+++ b/example/src/components/FormLifecycleEventsModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Modal,
   View,
   Text,
   FlatList,
@@ -8,6 +7,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import { FormLifecycleEventType } from 'klaviyo-react-native-sdk';
+import { BaseModal } from './BaseModal';
 import { colors, spacing, borderRadius, typography } from '../theme';
 import type { FormLifecycleLogEntry } from '../hooks/useForms';
 
@@ -42,112 +42,82 @@ export const FormLifecycleEventsModal: React.FC<
   FormLifecycleEventsModalProps
 > = ({ visible, events, onClose, onClear }) => {
   return (
-    <Modal
+    <BaseModal
       visible={visible}
-      animationType="slide"
-      transparent={true}
-      onRequestClose={onClose}
+      onClose={onClose}
+      title={`Form Lifecycle Events (${events.length})`}
+      maxHeight="80%"
     >
-      <View style={styles.overlay}>
-        <View style={styles.container}>
-          <Text style={styles.title}>
-            {`Form Lifecycle Events (${events.length})`}
+      {events.length === 0 ? (
+        <Text style={styles.emptyText}>
+          No form lifecycle events received yet. Register for in-app forms and
+          trigger one in your Klaviyo account.
+        </Text>
+      ) : (
+        <FlatList<FormLifecycleLogEntry>
+          data={events}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={({ item }) => {
+            const { event, receivedAt } = item;
+            return (
+              <View style={styles.eventItem}>
+                <View style={styles.eventHeader}>
+                  <Text style={styles.eventType}>{eventLabel(event.type)}</Text>
+                  <Text style={styles.eventTime}>
+                    {formatTimestamp(receivedAt)}
+                  </Text>
+                </View>
+                {/* Values are JSON.stringify'd so the modal functions as a
+                    protocol inspector — empty strings render as "" instead
+                    of being collapsed into placeholder text. */}
+                <Text
+                  style={styles.eventDetail}
+                >{`formId: ${JSON.stringify(event.formId)}`}</Text>
+                <Text
+                  style={styles.eventDetail}
+                >{`formName: ${JSON.stringify(event.formName)}`}</Text>
+                {event.type === FormLifecycleEventType.CtaClicked && (
+                  <>
+                    <Text
+                      style={styles.eventDetail}
+                    >{`buttonLabel: ${JSON.stringify(event.buttonLabel)}`}</Text>
+                    <Text
+                      style={styles.eventDetail}
+                    >{`deepLinkUrl: ${JSON.stringify(event.deepLinkUrl)}`}</Text>
+                  </>
+                )}
+              </View>
+            );
+          }}
+        />
+      )}
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.button, styles.clearButton]}
+          onPress={onClear}
+          disabled={events.length === 0}
+        >
+          <Text
+            style={[
+              styles.buttonText,
+              events.length === 0 && styles.buttonTextDisabled,
+            ]}
+          >
+            Clear
           </Text>
-          {events.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No form lifecycle events received yet. Register for in-app forms
-              and trigger one in your Klaviyo account.
-            </Text>
-          ) : (
-            <FlatList<FormLifecycleLogEntry>
-              data={events}
-              keyExtractor={(item) => String(item.id)}
-              renderItem={({ item }) => {
-                const { event, receivedAt } = item;
-                return (
-                  <View style={styles.eventItem}>
-                    <View style={styles.eventHeader}>
-                      <Text style={styles.eventType}>
-                        {eventLabel(event.type)}
-                      </Text>
-                      <Text style={styles.eventTime}>
-                        {formatTimestamp(receivedAt)}
-                      </Text>
-                    </View>
-                    {/* Values are JSON.stringify'd so the modal functions as a
-                        protocol inspector — empty strings render as "" instead
-                        of being collapsed into placeholder text. */}
-                    <Text
-                      style={styles.eventDetail}
-                    >{`formId: ${JSON.stringify(event.formId)}`}</Text>
-                    <Text
-                      style={styles.eventDetail}
-                    >{`formName: ${JSON.stringify(event.formName)}`}</Text>
-                    {event.type === FormLifecycleEventType.CtaClicked && (
-                      <>
-                        <Text
-                          style={styles.eventDetail}
-                        >{`buttonLabel: ${JSON.stringify(event.buttonLabel)}`}</Text>
-                        <Text
-                          style={styles.eventDetail}
-                        >{`deepLinkUrl: ${JSON.stringify(event.deepLinkUrl)}`}</Text>
-                      </>
-                    )}
-                  </View>
-                );
-              }}
-            />
-          )}
-          <View style={styles.buttonRow}>
-            <TouchableOpacity
-              style={[styles.button, styles.clearButton]}
-              onPress={onClear}
-              disabled={events.length === 0}
-            >
-              <Text
-                style={[
-                  styles.buttonText,
-                  events.length === 0 && styles.buttonTextDisabled,
-                ]}
-              >
-                Clear
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[styles.button, styles.closeButton]}
-              onPress={onClose}
-            >
-              <Text style={styles.buttonText}>Close</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.closeButton]}
+          onPress={onClose}
+        >
+          <Text style={styles.buttonText}>Close</Text>
+        </TouchableOpacity>
       </View>
-    </Modal>
+    </BaseModal>
   );
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.mdlg,
-  },
-  container: {
-    backgroundColor: colors.cardBackground,
-    borderRadius: borderRadius.md,
-    padding: spacing.mdlg,
-    width: '100%',
-    maxHeight: '80%',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: '600' as const,
-    color: colors.text,
-    marginBottom: spacing.md,
-    textAlign: 'center' as const,
-  },
   emptyText: {
     ...typography.label,
     color: colors.secondaryText,

--- a/example/src/components/GeofencesModal.tsx
+++ b/example/src/components/GeofencesModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Modal,
   View,
   Text,
   FlatList,
@@ -8,6 +7,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import { type Geofence } from 'klaviyo-react-native-sdk';
+import { BaseModal } from './BaseModal';
 import { colors, spacing, borderRadius, typography } from '../theme';
 
 interface GeofencesModalProps {
@@ -22,73 +22,43 @@ export const GeofencesModal: React.FC<GeofencesModalProps> = ({
   onClose,
 }) => {
   return (
-    <Modal
+    <BaseModal
       visible={visible}
-      animationType="slide"
-      transparent={true}
-      onRequestClose={onClose}
+      onClose={onClose}
+      title={`Monitored Geofences (${geofences.length})`}
+      maxHeight="80%"
     >
-      <View style={styles.overlay}>
-        <View style={styles.container}>
-          <Text style={styles.title}>
-            {`Monitored Geofences (${geofences.length})`}
-          </Text>
-          {geofences.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No geofences are currently being monitored.
-            </Text>
-          ) : (
-            <FlatList<Geofence>
-              data={geofences}
-              keyExtractor={(item) => item.identifier}
-              renderItem={({ item, index }) => (
-                <View style={styles.geofenceItem}>
-                  <Text style={styles.geofenceName}>
-                    {`${index + 1}. ${item.identifier}`}
-                  </Text>
-                  <Text style={styles.geofenceDetail}>
-                    {`Center: (${item.latitude.toFixed(6)}, ${item.longitude.toFixed(6)})`}
-                  </Text>
-                  <Text style={styles.geofenceDetail}>
-                    {`Radius: ${item.radius.toFixed(2)}m`}
-                  </Text>
-                </View>
-              )}
-            />
+      {geofences.length === 0 ? (
+        <Text style={styles.emptyText}>
+          No geofences are currently being monitored.
+        </Text>
+      ) : (
+        <FlatList<Geofence>
+          data={geofences}
+          keyExtractor={(item) => item.identifier}
+          renderItem={({ item, index }) => (
+            <View style={styles.geofenceItem}>
+              <Text style={styles.geofenceName}>
+                {`${index + 1}. ${item.identifier}`}
+              </Text>
+              <Text style={styles.geofenceDetail}>
+                {`Center: (${item.latitude.toFixed(6)}, ${item.longitude.toFixed(6)})`}
+              </Text>
+              <Text style={styles.geofenceDetail}>
+                {`Radius: ${item.radius.toFixed(2)}m`}
+              </Text>
+            </View>
           )}
-          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-            <Text style={styles.closeButtonText}>Close</Text>
-          </TouchableOpacity>
-        </View>
-      </View>
-    </Modal>
+        />
+      )}
+      <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+        <Text style={styles.closeButtonText}>Close</Text>
+      </TouchableOpacity>
+    </BaseModal>
   );
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    // No modal-overlay token in theme.ts; inline scrim. Consider adding a
-    // `colors.modalOverlay` token to theme.ts if more modals are introduced.
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: spacing.mdlg,
-  },
-  container: {
-    backgroundColor: colors.cardBackground,
-    borderRadius: borderRadius.md,
-    padding: spacing.mdlg,
-    width: '100%',
-    maxHeight: '80%',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: '600' as const,
-    color: colors.text,
-    marginBottom: spacing.md,
-    textAlign: 'center' as const,
-  },
   emptyText: {
     ...typography.label,
     color: colors.secondaryText,

--- a/example/src/hooks/useCompanyId.ts
+++ b/example/src/hooks/useCompanyId.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Klaviyo } from 'klaviyo-react-native-sdk';
+import { KLAVIYO_API_KEY } from '@env';
+
+const STORAGE_KEY = 'klaviyo_company_id_override';
+
+// The build-time default sourced from example/.env — same value used by the
+// module-scope Klaviyo.initialize() call in App.tsx.
+export const DEFAULT_COMPANY_ID: string = KLAVIYO_API_KEY ?? '';
+
+export function useCompanyId() {
+  const [companyId, setCompanyId] = useState(DEFAULT_COMPANY_ID);
+
+  useEffect(() => {
+    // Apply a persisted override if one exists. The module-scope initialize()
+    // in App.tsx already ran with the .env default; this re-inits only when
+    // the user has previously saved a different key.
+    AsyncStorage.getItem(STORAGE_KEY).then((stored) => {
+      if (stored && stored !== DEFAULT_COMPANY_ID) {
+        Klaviyo.resetProfile();
+        Klaviyo.initialize(stored);
+        setCompanyId(stored);
+      }
+    });
+  }, []);
+
+  const changeCompanyId = async (newKey: string) => {
+    await AsyncStorage.setItem(STORAGE_KEY, newKey);
+    Klaviyo.resetProfile();
+    Klaviyo.initialize(newKey);
+    setCompanyId(newKey);
+  };
+
+  const resetToDefault = async () => {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    Klaviyo.resetProfile();
+    Klaviyo.initialize(DEFAULT_COMPANY_ID);
+    setCompanyId(DEFAULT_COMPANY_ID);
+  };
+
+  return {
+    companyId,
+    isOverridden: companyId !== DEFAULT_COMPANY_ID,
+    changeCompanyId,
+    resetToDefault,
+  };
+}

--- a/example/src/theme.ts
+++ b/example/src/theme.ts
@@ -33,6 +33,9 @@ export const colors = {
   warningBackground: '#FFF4E5',
   warningBorder: '#FFB020',
   warningText: '#8B5A00',
+
+  // Modal scrim (semi-transparent backdrop behind modal content)
+  modalOverlay: 'rgba(0, 0, 0, 0.5)',
 };
 
 export const spacing = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,6 +2950,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-async-storage/async-storage@npm:^2.1.2":
+  version: 2.2.0
+  resolution: "@react-native-async-storage/async-storage@npm:2.2.0"
+  dependencies:
+    merge-options: ^3.0.4
+  peerDependencies:
+    react-native: ^0.0.0-0 || >=0.65 <1.0
+  checksum: efbb9c801fb7eecfad1568d6a5e9d247db420b8ba8f1789d5b783e679432567a53cf54c7e7b5e6f315276f33d1df297253549e0cefef2e683539df346d2a1f2d
+  languageName: node
+  linkType: hard
+
 "@react-native-community/cli-clean@npm:20.0.0":
   version: 20.0.0
   resolution: "@react-native-community/cli-clean@npm:20.0.0"
@@ -8015,6 +8026,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-obj@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-plain-obj@npm:2.1.0"
+  checksum: cec9100678b0a9fe0248a81743041ed990c2d4c99f893d935545cfbc42876cbe86d207f3b895700c690ad2fa520e568c44afc1605044b535a7820c1d40e38daa
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -8935,6 +8953,7 @@ __metadata:
     "@babel/core": ^7.25.2
     "@babel/preset-env": ^7.25.3
     "@babel/runtime": ^7.25.0
+    "@react-native-async-storage/async-storage": ^2.1.2
     "@react-native-community/cli": 20.0.0
     "@react-native-community/cli-platform-android": 20.0.0
     "@react-native-community/cli-platform-ios": 20.0.0
@@ -9457,6 +9476,15 @@ __metadata:
   version: 13.2.0
   resolution: "meow@npm:13.2.0"
   checksum: 79c61dc02ad448ff5c29bbaf1ef42181f1eae9947112c0e23db93e84cbc2708ecda53e54bfc6689f1e55255b2cea26840ec76e57a5773a16ca45f4fe2163ec1c
+  languageName: node
+  linkType: hard
+
+"merge-options@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "merge-options@npm:3.0.4"
+  dependencies:
+    is-plain-obj: ^2.1.0
+  checksum: d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Adds a debug-only settings affordance to the example app so the Klaviyo Company ID (public API key) used by the SDK can be swapped at runtime without rebuilding. Useful when bouncing between accounts/environments while exercising the SDK.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
  - Example-app-only change; no SDK behavior change. No new unit tests added.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
  - N/A — example-app dev affordance.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - JS-only (with one Swift-toolchain config file) — both platforms get the feature for free.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - Example-app-only change; nothing ships in the published SDK.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.

## Changelog / Code Overview

**New `useCompanyId` hook** (`example/src/hooks/useCompanyId.ts`)
- On mount, reads any persisted override from AsyncStorage. If one exists and differs from the build-time default, calls `Klaviyo.resetProfile()` then `Klaviyo.initialize(stored)` to rebind the SDK to that key.
- Exposes `companyId`, `isOverridden`, `changeCompanyId(newKey)`, `resetToDefault()`. Each mutator persists/clears the AsyncStorage entry and re-runs `resetProfile + initialize`.

**New `AppHeader`** (`example/src/components/AppHeader.tsx`)
- Fixed top bar with the app title and a `⚙` settings button.

**New `CompanyIdModal`** (`example/src/components/CompanyIdModal.tsx`)
- Displays the active Company ID, accepts a new value via TextInput (Save disabled when empty/unchanged), and conditionally renders a Reset to Default button when an override is in effect. Trims whitespace.

**App wiring** (`example/src/App.tsx`)
- Pulls in the hook, header, and modal. Module-scope `Klaviyo.initialize(KLAVIYO_API_KEY)` from `.env` is **intentionally unchanged** — the override is purely additive on top of the default integrator path that we document. Integrators reading the example shouldn't have to reason about the debug shim.

**Dependency**
- Adds `@react-native-async-storage/async-storage ^2.1.2` to the example app only.

**Unrelated cleanup: `.swiftlint.yml`**
- Small extra: adds a repo-root SwiftLint config that excludes `**/node_modules` and `**/Pods` (so we stop flagging vendored Swift code) and disables the arbitrary 250-line `type_body_length` rule. Drops lint findings from 6 (mostly inside dependencies) to 3 in our own bridge code. Pulled in here rather than its own PR because it's a few lines and was the lint surface I tripped over while wiring up this change.

## Test Plan

1. **Cold launch with default** — Fresh install / cleared storage. App boots; modal shows the `.env` Company ID; header chrome displays.
2. **Change ID via modal** — Tap ⚙, enter a different valid Company ID, Save. Modal closes, subsequent SDK calls (track event, identify) hit the new account. Verify in Klaviyo dashboard.
3. **Persistence across relaunch** — Force-quit the app and relaunch. The override persists; the modal shows the overridden ID with the `Default: …` hint underneath.
4. **Reset to Default** — Open the modal while overridden, tap Reset to Default. Modal closes, default Company ID is restored, and a subsequent relaunch confirms persistence cleared.
5. **Validation** — Save button is disabled when the input is empty or matches the active ID. Whitespace is trimmed.

## Related Issues/Tickets

None — debug affordance for the example app, intentionally untracked.