### PR TITLE
chore: bump to 2.4.0 (Android 4.4.0, Swift 5.3.1)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,8 +17,7 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-# saved: 4.3.1
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=rel~4.4.0-SNAPSHOT
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.4.0
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -115,6 +115,18 @@ else
     read -rp "Enter the Android SDK version: " android_version
   fi
 
+  # Swift SDK version
+  if [[ -z "$swift_version" ]]; then
+    read -rp "Enter the Swift SDK version: " swift_version
+  fi
+
+  # Reset any local SDK overrides before re-pinning. Re-uses configure-sdk.sh
+  # as the single source of truth for cleanup logic. This handles:
+  #   - Android: stale `# saved:` comments, localCompositeBuild flags
+  #   - iOS: Podfile pod entries, commented podspec pins, KlaviyoSwiftExtension overrides
+  echo "Resetting iOS and Android overrides via configure-sdk.sh..."
+  ./configure-sdk.sh --android gradle.properties --ios podspec --skip-pod-install
+
   gradle_properties="./android/gradle.properties"
   if [[ -f "$gradle_properties" ]]; then
     sed -i '' "s/KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=.*/KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=$android_version/" "$gradle_properties"
@@ -124,17 +136,28 @@ else
     exit 1
   fi
 
-  # Swift SDK version
-  if [[ -z "$swift_version" ]]; then
-    read -rp "Enter the Swift SDK version: " swift_version
-  fi
-
+  # Pin KlaviyoSwift, KlaviyoForms, KlaviyoLocation in the podspec.
+  # Accepts any of these starting forms per dep line (configure-sdk.sh can leave
+  # the second form behind when overriding to a branch/path; the bare form is
+  # what lands when working against an unreleased native version):
+  #   s.dependency "Name"
+  #   s.dependency "Name" ##, "old"
+  #   s.dependency "Name", "old"
+  # All three are normalized to: s.dependency "Name", "$swift_version"
   podspec_file="klaviyo-react-native-sdk.podspec"
   if [[ -f "$podspec_file" ]]; then
-    sed -i '' "s/\"KlaviyoSwift\", \".*\"/\"KlaviyoSwift\", \"$swift_version\"/" "$podspec_file"
-    sed -i '' "s/\"KlaviyoForms\", \".*\"/\"KlaviyoForms\", \"$swift_version\"/" "$podspec_file"
-    sed -i '' "s/\"KlaviyoLocation\", \".*\"/\"KlaviyoLocation\", \"$swift_version\"/" "$podspec_file"
-    echo "Updated KlaviyoSwift, KlaviyoForms, and KlaviyoLocation version in $podspec_file."
+    for dep in KlaviyoSwift KlaviyoForms KlaviyoLocation; do
+      # 1. Strip any existing pin or commented pin -> bare
+      sed -i '' -E "s/(s\\.dependency \"$dep\")( ##)?, \"[^\"]*\"/\\1/" "$podspec_file"
+      # 2. Append the new pin to the bare line
+      sed -i '' -E "s/(s\\.dependency \"$dep\")\$/\\1, \"$swift_version\"/" "$podspec_file"
+      # 3. Verify -- fail loud rather than silently shipping unpinned
+      if ! grep -qE "s\\.dependency \"$dep\", \"$swift_version\"" "$podspec_file"; then
+        echo "Error: failed to pin $dep to $swift_version in $podspec_file." >&2
+        exit 1
+      fi
+    done
+    echo "Pinned KlaviyoSwift, KlaviyoForms, and KlaviyoLocation to $swift_version in $podspec_file."
   else
     echo "Error: $podspec_file not found."
     exit 1

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -195,8 +195,8 @@ if [[ "$skip_native" == false ]]; then
       echo "Running bundle install..."
       bundle install || { echo "Error: Failed to run bundle install."; exit 1; }
     fi
-    echo "Running pod update for KlaviyoSwift, KlaviyoForms, and KlaviyoLocation..."
-    bundle exec pod update KlaviyoSwift KlaviyoForms KlaviyoLocation || { echo "Error: Failed to update pods."; exit 1; }
+    echo "Running pod update for Klaviyo pods..."
+    bundle exec pod update KlaviyoCore KlaviyoSwift KlaviyoForms KlaviyoLocation KlaviyoSwiftExtension || { echo "Error: Failed to update pods."; exit 1; }
     cd - || exit
   else
     echo "Error: $ios_dir not found."

--- a/configure-sdk.sh
+++ b/configure-sdk.sh
@@ -350,13 +350,21 @@ function configure_pods() {
   sed -i '' "/pod 'KlaviyoSwift'/d" "$podfile"
   sed -i '' "/pod 'KlaviyoForms'/d" "$podfile"
   sed -i '' "/pod 'KlaviyoLocation'/d" "$podfile"
+  sed -i '' "/pod 'KlaviyoSwiftExtension'/d" "$podfile"
 
   # Restore podspec
   sed -i '' 's/\(s\.dependency "KlaviyoSwift"\) ##, "\([^"]*\)"/\1, "\2"/' "$podspec"
   sed -i '' 's/\(s\.dependency "KlaviyoForms"\) ##, "\([^"]*\)"/\1, "\2"/' "$podspec"
   sed -i '' 's/\(s\.dependency "KlaviyoLocation"\) ##, "\([^"]*\)"/\1, "\2"/' "$podspec"
 
+  # Locate Extension target marker and prepare newline literal for sed insertions
+  local nl=$'\n'
+  local ext_marker_line
+  ext_marker_line=$(grep -n "# Insert override klaviyo-swift-sdk extension pod below this line when needed" "$podfile" | cut -d: -f1)
+
   if [[ "$swift_sdk_version" == "podspec" ]]; then
+    # Restore default extension pod entry (deleted above with the main pods)
+    sed -i '' "${ext_marker_line}a\\${nl}  pod 'KlaviyoSwiftExtension'${nl}" "$podfile"
     echo "Restored to $podspec"
     return
   fi
@@ -393,6 +401,23 @@ function configure_pods() {
     echo "Added $dependency dependency to $podfile"
     target_line=$((target_line + 1)) # Increment target line for next insertion
   done
+
+  # Insert KlaviyoSwiftExtension override into the Extension target (separate marker)
+  local ext_entry
+  if [[ "$swift_sdk_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+    ext_entry="pod 'KlaviyoSwiftExtension', '$swift_sdk_version'"
+  elif [[ "$swift_sdk_version" =~ ^(\./|\.\./).* ]]; then
+    ext_entry="pod 'KlaviyoSwiftExtension', :path => '$swift_sdk_version'"
+  elif [[ "$swift_sdk_version" =~ ^[a-f0-9]{7,40}$ ]]; then
+    ext_entry="pod 'KlaviyoSwiftExtension', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :commit => '$swift_sdk_version'"
+  else
+    ext_entry="pod 'KlaviyoSwiftExtension', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => '$swift_sdk_version'"
+  fi
+
+  # Re-locate marker since main target overrides shifted line numbers
+  ext_marker_line=$(grep -n "# Insert override klaviyo-swift-sdk extension pod below this line when needed" "$podfile" | cut -d: -f1)
+  sed -i '' "${ext_marker_line}a\\${nl}  $ext_entry${nl}" "$podfile"
+  echo "Added KlaviyoSwiftExtension dependency to $podfile"
 }
 
 # Execute configuration based on values

--- a/configure-sdk.sh
+++ b/configure-sdk.sh
@@ -429,13 +429,18 @@ fi
 if [[ "$ios_value" != "skip" ]]; then
   configure_pods "$ios_value"
 
-  # Handle pod install
+  # Refresh the Klaviyo pods. `pod update <names>` (vs plain `pod install`) is
+  # required because configure-sdk.sh is in the business of *changing* the pod
+  # source for those pods (podspec ↔ branch ↔ commit ↔ local path), and plain
+  # `pod install` refuses to bridge a Podfile.lock pin against a different
+  # source. Updating only the Klaviyo pods leaves the rest of Podfile.lock
+  # alone so unrelated deps (RN, Firebase, etc.) don't churn.
   if [[ "$skip_pod_install" == true ]]; then
-    echo "Skipped 'pod install'"
+    echo "Skipped pod refresh"
   else
-    echo "Running 'pod install'..."
+    echo "Running 'pod update' for Klaviyo pods..."
     cd ./example/ios || { echo "Error: Directory ./example/ios not found."; exit 1; }
-    bundle exec pod install
-    echo "'pod install' completed successfully."
+    bundle exec pod update KlaviyoCore KlaviyoSwift KlaviyoForms KlaviyoLocation KlaviyoSwiftExtension
+    echo "Pod refresh completed successfully."
   fi
 fi

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -81,6 +81,7 @@ end
 
 target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
+  # Insert override klaviyo-swift-sdk extension pod below this line when needed
   pod 'KlaviyoSwiftExtension'
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -39,10 +39,6 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
-  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
-  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
-  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
-  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.3.0'
 
   # Setup permissions for react-native-permissions
   setup_permissions([

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -64,20 +64,20 @@ PODS:
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
   - klaviyo-react-native-sdk (2.4.0):
-    - KlaviyoForms
-    - KlaviyoLocation
-    - KlaviyoSwift
+    - KlaviyoForms (= 5.3.1)
+    - KlaviyoLocation (= 5.3.1)
+    - KlaviyoSwift (= 5.3.1)
     - React-Core
-  - KlaviyoCore (5.3.0):
+  - KlaviyoCore (5.3.1):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.3.0):
-    - KlaviyoSwift (~> 5.3.0)
-  - KlaviyoLocation (5.3.0):
-    - KlaviyoSwift (~> 5.3.0)
-  - KlaviyoSwift (5.3.0):
+  - KlaviyoForms (5.3.1):
+    - KlaviyoSwift (~> 5.3.1)
+  - KlaviyoLocation (5.3.1):
+    - KlaviyoSwift (~> 5.3.1)
+  - KlaviyoSwift (5.3.1):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.3.0)
-  - KlaviyoSwiftExtension (5.2.3)
+    - KlaviyoCore (~> 5.3.1)
+  - KlaviyoSwiftExtension (5.3.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2544,10 +2544,6 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
-  - KlaviyoCore (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
-  - KlaviyoForms (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
-  - KlaviyoLocation (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
-  - KlaviyoSwift (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.3.0`)
   - KlaviyoSwiftExtension
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2632,6 +2628,10 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
+    - KlaviyoCore
+    - KlaviyoForms
+    - KlaviyoLocation
+    - KlaviyoSwift
     - KlaviyoSwiftExtension
     - nanopb
     - PromisesObjC
@@ -2655,18 +2655,6 @@ EXTERNAL SOURCES:
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
   klaviyo-react-native-sdk:
     :path: "../.."
-  KlaviyoCore:
-    :branch: rel/5.3.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoForms:
-    :branch: rel/5.3.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoLocation:
-    :branch: rel/5.3.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwift:
-    :branch: rel/5.3.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2806,20 +2794,6 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
-CHECKOUT OPTIONS:
-  KlaviyoCore:
-    :commit: 2bdf794c4a2cc22c9b8f731a5e6b8c17d025f8c1
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoForms:
-    :commit: 2bdf794c4a2cc22c9b8f731a5e6b8c17d025f8c1
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoLocation:
-    :commit: 2bdf794c4a2cc22c9b8f731a5e6b8c17d025f8c1
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwift:
-    :commit: 2bdf794c4a2cc22c9b8f731a5e6b8c17d025f8c1
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-
 SPEC CHECKSUMS:
   AnyCodable-FlightSchool: 261cbe76757802b17d471b9059b21e6fa5edf57b
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -2837,12 +2811,12 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: a6a954a9f3206771303e23c49a0618eb4ceb5218
-  KlaviyoCore: 0735e9f71d29c7dfb7b1301845b6986ccf566bcd
-  KlaviyoForms: 589f91cb245dbf78f657cbc46a1d3dab47bef601
-  KlaviyoLocation: 9ba7810b0cbe1205dad0903c42dc420ba8dd6025
-  KlaviyoSwift: 6cad13c24d067c615db499984136d0273eaf9a36
-  KlaviyoSwiftExtension: 963bedfdb2dbc303c89792933f052edf907f0dbb
+  klaviyo-react-native-sdk: 021a6341807e8cbc03e595e5b499276cb115c641
+  KlaviyoCore: 37750d289e7113277899f6a2c9f8f088e732d869
+  KlaviyoForms: 7e69da16880700be263b819e542255d2b639507a
+  KlaviyoLocation: 07b9a74ebcef661310b22f4be6ebd0e03c816793
+  KlaviyoSwift: 5406447e2e594c47c80d9442c67ac088b92cc77e
+  KlaviyoSwiftExtension: cf8257a28734e076224560fe7379a8eb6aa94270
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
@@ -2916,6 +2890,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: 87ff0b83228d6931b0001904a5a647220916671d
+PODFILE CHECKSUM: 1ab968cc8cc5357131b42b0efa05d7865588a201
 
 COCOAPODS: 1.16.2

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift"
+  s.dependency "KlaviyoSwift", "5.3.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation"
+    s.dependency "KlaviyoLocation", "5.3.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms"
+    s.dependency "KlaviyoForms", "5.3.1"
   end
 
   s.default_subspecs = :none


### PR DESCRIPTION
# Description

Bump the React Native SDK to 2.4.0, pinning native dependencies to Klaviyo Android 4.4.0 and Klaviyo Swift 5.3.1. Also fixes three latent bugs in the version-bump and SDK-configuration helper scripts that were silently no-op'ing or fighting each other when the podspec / Podfile / gradle.properties were left in non-default states.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [x] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

**`f5cb130` — `fix(scripts): pin podspec / clean overrides on version bump`**

Two latent script bugs surfaced while preparing this release:

1. `bump-version.sh`'s `sed` for `KlaviyoSwift`/`Forms`/`Location` only matched an existing pinned form (`"Name", "x.y.z"`). It silently no-op'd against:
   - a bare line (`s.dependency "KlaviyoSwift"`), which is what lands when working against unreleased native versions, and
   - the `s.dependency "KlaviyoSwift" ##, "x.y.z"` form left behind by `configure-sdk.sh` after a local override.
2. The Android path left behind a stale `# saved:` comment after `bump-version.sh` ran. `configure-sdk.sh` later treated that comment as the source of truth on the next `--android gradle.properties`, silently reverting the bump.

Fix: `bump-version.sh` now shells out to `./configure-sdk.sh --android gradle.properties --ios podspec --skip-pod-install` first, scrubbing both stacks via the helper that owns the cleanup logic. Then it pins the podspec with a sed pair that handles bare / `##, "x"` / pinned uniformly, with a `grep` verify-or-`exit 1` guard so silent no-ops fail loudly going forward.

`configure-sdk.sh` also gains `KlaviyoSwiftExtension` override support so its podspec-restore path restores the default Extension pod entry, and its override path injects the matching `KlaviyoSwiftExtension` entry into the example app's Extension target. The Podfile gets a placeholder marker comment so the script knows where to insert.

**`5e41fbd` — `chore: bump native SDKs to Android 4.4.0 / Swift 5.3.1`**

Output of `./bump-version.sh -v 2.4.0 -a 4.4.0 -s 5.3.1`. All five Klaviyo pods (Core, Swift, Forms, Location, Extension) resolve to 5.3.1 in the example app's `Podfile.lock`.

Why 5.3.1 over 5.3.0: 5.3.1 patches a CocoaPods integration issue introduced in 5.3.0 — `KlaviyoSwiftExtension` drops its `KlaviyoCore` dependency and inlines shared types, fixing a link failure for apps using `KlaviyoSwiftExtension` in a Notification Service Extension target. ([5.3.1 release notes](https://github.com/klaviyo/klaviyo-swift-sdk/releases/tag/5.3.1))

**`76b8a2a` — `fix(scripts): use targeted pod update instead of pod install`**

`configure-sdk.sh` exists to swap the *source* of the Klaviyo pods (podspec ↔ branch ↔ commit ↔ local path). Plain `pod install` honors the `Podfile.lock` pin, so it errors out every time the source has changed:

```
[!] CocoaPods could not find compatible versions for pod "KlaviyoForms":
  In snapshot (Podfile.lock):
    KlaviyoForms (= 5.3.1)
  In Podfile:
    KlaviyoForms (from `…klaviyo-swift-sdk.git`, branch `<branch>`)
```

Switched both `configure-sdk.sh` and `bump-version.sh` to `pod update KlaviyoCore KlaviyoSwift KlaviyoForms KlaviyoLocation KlaviyoSwiftExtension` — re-resolves only the Klaviyo pods and leaves React Native / Firebase / etc. untouched. `bump-version.sh` previously updated only three of the five (omitting Core and Extension), letting Extension drift; now all five stay in lockstep.

## Test Plan

- [x] `./bump-version.sh -v 2.4.0 -a 4.4.0 -s 5.3.1` from a working tree with `configure-sdk.sh`-style overrides produces a clean podspec (pinned 5.3.1), clean `gradle.properties` (4.4.0, no `# saved:` artifact), clean `Podfile` (overrides removed, Extension placeholder restored), and a `Podfile.lock` with all five Klaviyo pods at 5.3.1.
- [x] `./configure-sdk.sh --ios <branch>` followed by `./configure-sdk.sh --ios podspec` round-trips cleanly — pod sources swap without `pod install` lockfile errors.
- [ ] Build example app on iOS simulator and confirm forms / push / analytics call paths.
- [ ] Build example app on Android emulator and confirm forms / push / analytics call paths.
- [ ] Verify SDK reports version `2.4.0` to backend in tracked events.

## Related Issues/Tickets

Part of MAGE-452.