### PR TITLE
ci(example): un-draft Play release, attach release notes, link install URL, platform-selective triggers

### DIFF
--- a/.github/actions/notify-slack-publish/action.yml
+++ b/.github/actions/notify-slack-publish/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Version string to show in the message (e.g. release tag or 'X.Y.Z (build)')
     required: false
     default: manual
+  install_url:
+    description: Optional install link to surface in the message (e.g. internal-sharing download URL). Only useful to users already authorized for the build.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -32,7 +36,7 @@ runs:
             - type: "section"
               text:
                 type: "mrkdwn"
-                text: "*Repository:* ${{ github.repository }}\n*Workflow:* ${{ github.workflow }}\n*Version:* `${{ inputs.version_label }}`\n*Commit:* `${{ github.sha }}`\n*Author:* ${{ github.actor }}"
+                text: "*Repository:* ${{ github.repository }}\n*Workflow:* ${{ github.workflow }}\n*Version:* `${{ inputs.version_label }}`\n*Commit:* `${{ github.sha }}`\n*Author:* ${{ github.actor }}${{ inputs.install_url != '' && format('\n*Install:* <{0}|Tap to install build>', inputs.install_url) || '' }}"
             - type: "section"
               text:
                 type: "mrkdwn"

--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -1,14 +1,32 @@
 # Publish the example app to Play internal track + TestFlight. Android and
 # iOS are independent jobs.
 #
-# Triggers: manual dispatch, release: published, push to master, and
-# `pull_request: labeled` when the label is `deploy-example-app` (the
-# cleanup-label job below removes it after the run so reapplying re-triggers).
+# Triggers:
+#   - workflow_dispatch     (manual; choose `both` / `android` / `ios`)
+#   - release: published    (both platforms)
+#   - push to master        (both platforms)
+#   - pull_request: labeled (label drives platform selection — see below)
+#
+# Label conventions (cleanup-label removes them after the run so reapplying
+# re-triggers):
+#   - `deploy-example-app`         → both platforms
+#   - `deploy-example-app:android` → Android only
+#   - `deploy-example-app:ios`     → iOS only
 
 name: Publish Example App
 
 on:
   workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Which platform(s) to publish'
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - android
+          - ios
   release:
     types: [published]
   push:
@@ -20,8 +38,14 @@ jobs:
   deploy-android:
     name: Publish to Play Store internal track
     runs-on: ubuntu-24.04
-    # On pull_request, only run if the added label is deploy-example-app.
-    if: github.event_name != 'pull_request' || github.event.label.name == 'deploy-example-app'
+    # Run on release / push always; on workflow_dispatch when platform is
+    # `both` or `android`; on labeled PR when the label is `deploy-example-app`
+    # (umbrella) or `deploy-example-app:android`.
+    if: |
+      github.event_name == 'release'
+      || github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && (inputs.platform == 'both' || inputs.platform == 'android'))
+      || (github.event_name == 'pull_request' && (github.event.label.name == 'deploy-example-app' || github.event.label.name == 'deploy-example-app:android'))
 
     steps:
       - uses: actions/checkout@v5
@@ -171,7 +195,14 @@ jobs:
     runs-on: macos-26
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
-    if: github.event_name != 'pull_request' || github.event.label.name == 'deploy-example-app'
+    # Run on release / push always; on workflow_dispatch when platform is
+    # `both` or `ios`; on labeled PR when the label is `deploy-example-app`
+    # (umbrella) or `deploy-example-app:ios`.
+    if: |
+      github.event_name == 'release'
+      || github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && (inputs.platform == 'both' || inputs.platform == 'ios'))
+      || (github.event_name == 'pull_request' && (github.event.label.name == 'deploy-example-app' || github.event.label.name == 'deploy-example-app:ios'))
 
     steps:
       - uses: actions/checkout@v5
@@ -407,17 +438,23 @@ jobs:
           platform: TestFlight
           version_label: ${{ env.MARKETING_VERSION || '?' }} (${{ env.BUILD_NUMBER || '?' }})
 
-  # Remove the deploy-example-app label after the run so reapplying re-triggers.
+  # Remove the deploy-example-app[:platform] label after the run so reapplying
+  # re-triggers. Handles all three variants: umbrella, :android, :ios.
   cleanup-label:
     name: Remove deploy-example-app label
     needs: [deploy-android, deploy-ios]
-    if: always() && github.event_name == 'pull_request' && github.event.label.name == 'deploy-example-app'
+    if: |
+      always()
+      && github.event_name == 'pull_request'
+      && startsWith(github.event.label.name, 'deploy-example-app')
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:
       - name: Remove label
         uses: actions/github-script@v7
+        env:
+          LABEL_NAME: ${{ github.event.label.name }}
         with:
           script: |
             try {
@@ -425,7 +462,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                name: 'deploy-example-app',
+                name: process.env.LABEL_NAME,
               });
             } catch (e) {
               // 404 = label already gone (e.g. removed manually mid-run).

--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -122,7 +122,11 @@ jobs:
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           mkdir -p "${RUNNER_TEMP}/whatsnew"
-          printf '%s' "${RELEASE_BODY}" | head -c 500 > "${RUNNER_TEMP}/whatsnew/whatsnew-en-US"
+          # Bash parameter expansion truncates by character (locale-aware,
+          # ubuntu-24.04 runners default to en_US.UTF-8), so emojis or
+          # non-ASCII text near the boundary don't get split mid-byte —
+          # which would produce invalid UTF-8 and risk a Play Store reject.
+          printf '%s' "${RELEASE_BODY:0:500}" > "${RUNNER_TEMP}/whatsnew/whatsnew-en-US"
           echo "WHATSNEW_DIR=${RUNNER_TEMP}/whatsnew" >> "${GITHUB_ENV}"
 
       - name: Deploy to Internal Track

--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -110,16 +110,31 @@ jobs:
             -Pandroid.injected.signing.key.alias="${ALIAS}" \
             -Pandroid.injected.signing.key.password="${KEY_PASSWORD}"
 
-      # `status: draft` is required while the listing has no published
-      # version. Flip to `completed` once the listing is fully configured.
+      # On `release: published`, write the GitHub release body into a
+      # `whatsnew-en-US` file so the upload action attaches it as Play Store
+      # release notes. Truncate to 500 chars per Google's per-locale cap.
+      # Other triggers (workflow_dispatch / push / labeled PR) skip this and
+      # the release lands without notes.
+      - name: Prepare release notes
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/whatsnew"
+          printf '%s' "${RELEASE_BODY}" | head -c 500 > "${RUNNER_TEMP}/whatsnew/whatsnew-en-US"
+          echo "WHATSNEW_DIR=${RUNNER_TEMP}/whatsnew" >> "${GITHUB_ENV}"
+
       - name: Deploy to Internal Track
+        id: play_upload
         uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           packageName: com.klaviyoreactnativesdkexample
           releaseFiles: example/android/app/build/outputs/bundle/release/app-release.aab
           track: internal
-          status: draft
+          status: completed
+          whatsNewDirectory: ${{ env.WHATSNEW_DIR }}
 
       - name: Clean up keystore
         if: always()
@@ -133,6 +148,10 @@ jobs:
           result: success
           platform: Play Store
           version_label: ${{ env.VERSION_NAME }} (${{ env.VERSION_CODE }})
+          # The action emits this for every non-internalsharing track too —
+          # it's the standard `play.google.com/apps/test/<pkg>/<code>` URL,
+          # only resolvable by users already authorized for the build.
+          install_url: ${{ steps.play_upload.outputs.internalSharingDownloadUrl }}
 
       - name: Notify Slack on failure
         if: failure()


### PR DESCRIPTION
# Description

Targeted improvements to the example app's Play Store + TestFlight publish workflow now that the listing is mature enough for non-draft submissions, plus tighter trigger granularity so we can publish one platform at a time when needed.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

> Note on iOS feature parity: TestFlight side stays unchanged for the install-link / release-notes parts because `xcrun altool` (the Apple uploader we use) doesn't emit an install URL — there's no symmetric link to surface in Slack. Release notes for TestFlight ("What to Test") would require a separate API call we don't currently make. Out of scope for this PR. Trigger-selectivity is symmetric across both platforms.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

CI-only change, no SDK API surface affected.

## Changelog / Code Overview

**1. `status: draft` → `status: completed`**

The listing now has active builds on **internal** *and* **closed** test tracks, so the per-app "Set up your app" requirements are satisfied. Non-draft submissions on the internal track now go live for testers automatically instead of sitting in the Play Console as drafts waiting for manual promotion.

**2. Release notes from GitHub release body**

`r0adkll/upload-google-play@v1.1.3` accepts a `whatsNewDirectory` containing `whatsnew-<locale>` files. On `release: published` events, the workflow writes `${{ github.event.release.body }}` (truncated to Play's 500-char per-locale cap, character-aware via bash parameter expansion to avoid splitting multi-byte UTF-8 — caught by Cursor Bugbot, see [reply](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/354#discussion_r3173451673)) to `${RUNNER_TEMP}/whatsnew/whatsnew-en-US` and passes the dir to the upload action. Other triggers (manual dispatch, push to master, labeled PR) skip the prep step and the build lands without notes — those builds aren't user-facing releases anyway.

**3. Install URL in Slack notification**

Reading the upload action's source ([edits.ts:97–99](https://github.com/r0adkll/upload-google-play/blob/v1.1.3/src/edits.ts#L97-L99)), the `internalSharingDownloadUrl` output is emitted **for every non-`internalsharing` track**, not just for the `internalsharing` track as the action's `action.yml` docstring suggests. The URL format is `https://play.google.com/apps/test/<package>/<versionCode>` and is only resolvable by users already authorized for the build (no enrollment leak), making it safe to post to a public Slack channel.

The Deploy step now has `id: play_upload`, the success-notification step passes `install_url: ${{ steps.play_upload.outputs.internalSharingDownloadUrl }}`, and the `notify-slack-publish` composite action gained an optional `install_url` input that conditionally renders an `Install: <url>` line in the existing details section.

**4. Platform-selective triggers**

Today the workflow is all-or-nothing — every trigger publishes both Android and iOS. New behavior:

| Trigger | Behavior |
|---|---|
| `workflow_dispatch` | New `platform` input dropdown: `both` (default) / `android` / `ios` |
| `pull_request` labeled `deploy-example-app` | Both platforms (existing behavior preserved) |
| `pull_request` labeled `deploy-example-app:android` | Android only |
| `pull_request` labeled `deploy-example-app:ios` | iOS only |
| `release: published` | Both platforms (unchanged) |
| `push` to master | Both platforms (unchanged) |

The cleanup-label job widened to remove whichever variant was applied (`startsWith('deploy-example-app')` filter, label name pulled from event payload via env var so dynamic).

> ⚠️ **Repo-settings task:** The new `deploy-example-app:android` and `deploy-example-app:ios` labels need to be created in the repo's Issues → Labels page before they can be applied to PRs. GitHub auto-creates labels for some flows but `pull_request: labeled` triggers require pre-existing labels.

## Test Plan

- [x] YAML parses cleanly (verified via `python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] Bash parameter expansion verified character-aware locally (`hé€ll` → 5 chars / 8 bytes, no mid-codepoint cut).
- [ ] Trigger the publish workflow via `workflow_dispatch` against this branch with `platform: android`, confirm only the Android job runs.
- [ ] Same with `platform: ios`, confirm only the iOS job runs.
- [ ] Same with `platform: both`, confirm both jobs run (regression check on the default path).
- [ ] Apply the `deploy-example-app:android` label to a test PR, confirm only the Android job runs and the label gets removed afterward.
- [ ] Confirm the existing `deploy-example-app` (umbrella) label still triggers both jobs (regression check).
- [ ] On the next 2.4.0 GitHub release, confirm the release body shows up as the Play Store internal-track release notes (and that the 500-char truncation behaves on a long body with emojis).
- [ ] Confirm the Slack message renders with the new `Install:` line and the URL opens correctly for an enrolled tester.

## Related Issues/Tickets

Follow-up to MAGE-452 (Release RN v2.4.0). Depends on #353 merging first since this branches from `ecm/bump-version`'s tip — once #353 lands on `rel/2.4.0`, this diff against `rel/2.4.0` reduces to just the four changes above.