### PR TITLE
fix(example): gate Badge Count behind iOS, not Android

### DIFF
--- a/example/src/sections/PushSection.tsx
+++ b/example/src/sections/PushSection.tsx
@@ -56,7 +56,7 @@ export function PushSection() {
             title="Set Push Token"
             onPress={push.handleSetPushToken}
           />
-          {(Platform.OS === 'android' || push.pushNotificationsEnabled) && (
+          {Platform.OS === 'ios' && push.pushNotificationsEnabled && (
             <ProfileTextField
               label="Badge Count"
               value={push.badgeCount}


### PR DESCRIPTION
# Description

Fixes an inverted platform check in the example app's Push section that was rendering the Badge Count input on Android (where the SDK can't set badges) and hiding it on iOS until permission was granted.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Example-app-only fix, no SDK API surface affected.

## Changelog / Code Overview

`example/src/sections/PushSection.tsx:59` was:

```tsx
{(Platform.OS === 'android' || push.pushNotificationsEnabled) && (
```

— platforms inverted. `setBadgeCount` is iOS-only at every layer:

- Swift bridge implements it: [`ios/KlaviyoReactNativeSdk.mm:86`](https://github.com/klaviyo/klaviyo-react-native-sdk/blob/rel/2.4.0/ios/KlaviyoReactNativeSdk.mm#L86), [`ios/KlaviyoBridge.swift:254`](https://github.com/klaviyo/klaviyo-react-native-sdk/blob/rel/2.4.0/ios/KlaviyoBridge.swift#L254).
- Android Kotlin bridge does not implement it.
- The JS layer in `src/index.tsx:75` has a runtime guard that no-ops on Android with the comment `"this is iOS only and don't want a runtime error on android"`.

So Android users were seeing a non-functional input that silently logged `"setBadgeCount is not available on this platform"` when they tapped Set, while iOS users had the input disappear when they hadn't granted notification permission yet.

Fix:

```tsx
{Platform.OS === 'ios' && push.pushNotificationsEnabled && (
```

The permission gate stays because badge updates are no-ops without notification permission on iOS too — better to hide than expose a dead control.

## Test Plan

- [x] `tsc --noEmit` clean.
- [ ] Run example app on iOS simulator: confirm Badge Count field appears only after granting push permission, and that tapping Set updates the springboard badge.
- [ ] Run example app on Android emulator: confirm Badge Count field is no longer rendered at all (regardless of permission state).

## Related Issues/Tickets

Found while reviewing the rebuilt example app. Bug introduced in `7b9d0f1 feat(example): rebuild app with sectioned UI, JS-first init, API coverage` — already on `rel/2.4.0` via the example-rebuild PR. Not yet on `master` (rebuild hasn't propagated there yet), so a single fix on `rel/2.4.0` is sufficient — when `rel/2.4.0` merges back to master, the corrected version goes with it.

Part of MAGE-452.