### PR TITLE
test(forms): cover double-unsubscribe and unavailable-module paths

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -73,7 +73,19 @@ jest.mock('react-native', () => {
           eventListeners[eventName] = [];
         }
         eventListeners[eventName]!.push(callback);
-        return { remove: mockRemove };
+        // `remove` both bumps the spy (so existing tests that assert
+        // `mockRemove.toHaveBeenCalled*` keep working) and actually splices
+        // the callback out of `eventListeners` so subsequent
+        // `emitNativeEvent` calls don't reach detached listeners.
+        const remove = () => {
+          mockRemove();
+          const arr = eventListeners[eventName];
+          if (arr) {
+            const idx = arr.indexOf(callback);
+            if (idx >= 0) arr.splice(idx, 1);
+          }
+        };
+        return { remove };
       }),
     })),
     Platform: {
@@ -605,6 +617,25 @@ describe('Klaviyo SDK', () => {
       ).toHaveBeenCalledTimes(1);
     });
 
+    it('should be safe to call the unsubscribe function more than once', () => {
+      const handler = jest.fn();
+      const unsubscribe = Klaviyo.registerFormLifecycleHandler(handler);
+
+      // Calling unsubscribe twice should not throw, and the handler should
+      // remain unregistered. Behavioral check only — the implementation may
+      // re-fire native unregister defensively, which is intentional.
+      unsubscribe();
+      expect(() => unsubscribe()).not.toThrow();
+
+      emitNativeEvent('FormLifecycleEvent', {
+        type: 'formShown',
+        formId: 'abc123',
+        formName: 'Test Form',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('should clean up previous subscription when re-registering', () => {
       const handler1 = jest.fn();
       const handler2 = jest.fn();
@@ -622,6 +653,41 @@ describe('Klaviyo SDK', () => {
       expect(
         NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
       ).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs error and noops when KlaviyoForms module is not available', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const defaultConstants =
+        NativeModules.KlaviyoReactNativeSdk.getConstants();
+      NativeModules.KlaviyoReactNativeSdk.getConstants.mockReturnValue({
+        ...defaultConstants,
+        FORMS_AVAILABLE: false,
+      });
+
+      try {
+        const handler = jest.fn();
+        const unsubscribe = Klaviyo.registerFormLifecycleHandler(handler);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('KlaviyoForms')
+        );
+        expect(
+          NativeModules.KlaviyoReactNativeSdk.registerFormLifecycleHandler
+        ).not.toHaveBeenCalled();
+
+        // The returned no-op must be safe to call and must not touch the
+        // native bridge — there's no listener or native registration to tear
+        // down on the no-op path.
+        expect(() => unsubscribe()).not.toThrow();
+        expect(
+          NativeModules.KlaviyoReactNativeSdk.unregisterFormLifecycleHandler
+        ).not.toHaveBeenCalled();
+      } finally {
+        NativeModules.KlaviyoReactNativeSdk.getConstants.mockReturnValue(
+          defaultConstants
+        );
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it('should not forward events with missing formId', () => {


### PR DESCRIPTION
# Description

Closes two test coverage gaps in `registerFormLifecycleHandler` that @ndurell flagged on [PR #339](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/339#issuecomment-4347638685). Tests-only — no runtime behavior change.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Test-only change, no SDK API surface affected.

## Changelog / Code Overview

**Two new tests in the `form lifecycle events` describe block:**

1. **"should be safe to call the unsubscribe function more than once"** — registers a handler, calls the returned cleanup twice, asserts no throw, then emits a `formShown` event and asserts the handler is not called. Behavioral check only — the implementation is allowed (and expected) to re-fire the native unregister defensively for cleanup-state guarantees, so the test does not pin down native call counts.

2. **"logs error and noops when KlaviyoForms module is not available"** — mirrors the existing `registerForInAppForms` / `unregisterFromInAppForms` unavailability test pattern (lines 293–326). Forces `FORMS_AVAILABLE: false`, asserts the standard error log, asserts the native register call doesn't fire, and asserts the returned no-op unsubscribe is safe to invoke without touching the native bridge.

**Mock fidelity fix** in the `NativeEventEmitter` mock setup: the previous `addListener` returned a `remove` that was just the global `mockRemove` jest.fn() — calling it incremented the spy but **did not actually splice the callback out of `eventListeners`**, so emitted events would keep reaching detached handlers. New behavior: `remove` both bumps `mockRemove` (so existing `toHaveBeenCalled*` assertions keep working) and splices the callback. This is what made the new double-unsubscribe test meaningful — without it, the test would pass even on broken implementations.

## Test Plan

- [x] `yarn test` — 57 / 57 passing locally (existing 55 + 2 new).
- [x] `yarn typecheck` — clean.
- [x] `yarn lint` — only pre-existing Swift warnings (untouched files).

## Related Issues/Tickets

Follow-up to MAGE-451 / MAGE-452. Targets `rel/2.4.0` since the `registerFormLifecycleHandler` API first ships publicly with 2.4.0.