### PR TITLE
fix(scripts): override yarn's CI immutable-install default in pack-and-test

### DIFF
--- a/pack-and-test.sh
+++ b/pack-and-test.sh
@@ -167,8 +167,12 @@ cmd_setup() {
   clear_metro_caches
 
   SETUP_PROGRESS="installed"
-  echo "==> Installing in example/ (drops --immutable, package.json changed)"
-  (cd "$EXAMPLE" && yarn install)
+  # We just rewrote example/package.json, so yarn install MUST update the
+  # lockfile. yarn 3 defaults `enableImmutableInstalls` to true when CI=true,
+  # which would block this even without an explicit --immutable flag — set
+  # the env var inline so it applies just to this invocation.
+  echo "==> Installing in example/ (yarn.lock will be rewritten — file: dep added)"
+  (cd "$EXAMPLE" && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install)
 
   SETUP_PROGRESS="done"
 
@@ -225,8 +229,10 @@ cmd_restore() {
   rm -f "$INSTALL_STATE"
   clear_metro_caches
 
-  echo "==> Reinstalling dependencies"
-  (cd "$EXAMPLE" && yarn install)
+  # Same `enableImmutableInstalls` carve-out as setup — we just restored
+  # example/package.json from backup so the lockfile flips back too.
+  echo "==> Reinstalling dependencies (yarn.lock reverts to workspace state)"
+  (cd "$EXAMPLE" && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install)
 
   rm -rf "$TARBALL_DIR"
 


### PR DESCRIPTION
# Description

Hotfix: the recently merged `pack-and-test.sh` (#356) fails on CI because yarn 3 defaults `enableImmutableInstalls` to true on CI runners (when `CI=true` env var is set), so `yarn install` aborts with YN0028 even when we don't pass `--immutable`. The Pack SDK step modified `example/package.json` and then ran `yarn install` expecting the lockfile to update — yarn refused.

Reproduced live on the latest publish workflow run: https://github.com/klaviyo/klaviyo-react-native-sdk/actions/runs/25341800138/job/74300675814

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

> Locally reproduced the failure by running `CI=true ./pack-and-test.sh setup` (which mimics the runner) and confirmed it now passes with the fix applied.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

CI tooling fix only.

## Changelog / Code Overview

`pack-and-test.sh setup` and `restore` both run `yarn install` after rewriting `example/package.json` (setup adds the `file:` dep, restore removes it). Per [yarn 3 docs](https://yarnpkg.com/configuration/yarnrc#enableImmutableInstalls):

> `enableImmutableInstalls`: Defaults to true on CI (when the CI environment variable is set).

So on CI, `yarn install` is implicitly `--immutable` and yarn refuses to update the lockfile. The script's prior comment ("drops --immutable") was technically true (we don't pass the flag) but missed the implicit CI-mode default.

Fix: prefix the yarn install invocation with `YARN_ENABLE_IMMUTABLE_INSTALLS=false` so it applies only to this command. Other yarn invocations on the runner (the composite Setup action's `yarn install --immutable`) keep their current behavior.

```diff
- echo "==> Installing in example/ (drops --immutable, package.json changed)"
- (cd "$EXAMPLE" && yarn install)
+ echo "==> Installing in example/ (yarn.lock will be rewritten — file: dep added)"
+ (cd "$EXAMPLE" && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install)
```

Same change in `cmd_restore`.

## Test Plan

- [x] `bash -n` clean.
- [x] `CI=true ./pack-and-test.sh setup` succeeds locally (reproduces the runner condition that was failing).
- [x] `CI=true ./pack-and-test.sh restore` round-trips back to clean state.
- [ ] Re-run the publish workflow on `rel/2.4.0` after merge, confirm the Android Pack SDK step succeeds and the Play internal-track upload completes.

## Related Issues/Tickets

Hotfix follow-up to #356. Part of MAGE-452 (Release RN v2.4.0).