### PR TITLE
fix(android): guard sendEvent against catalyst-instance teardown

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -49,9 +49,25 @@ class KlaviyoReactNativeSdkModule(
     eventName: String,
     params: WritableMap?,
   ) {
-    reactContext
-      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-      .emit(eventName, params)
+    // Form lifecycle callbacks fire from the native SDK and can race the
+    // host Activity/Process being torn down (background → low-memory kill,
+    // config change, deep-link launch from CTA, dev-mode HMR/fast-refresh).
+    // `getJSModule` throws `RuntimeException: Catalyst Instance has already
+    // disappeared` in that window, so guard the call. Pattern mirrors RN's
+    // own AppStateModule.sendEvent fix.
+    // Using `hasActiveCatalystInstance` (deprecated alias of
+    // `hasActiveReactInstance`) for broader peer-dep range — the SDK's
+    // peerDependencies allow any react-native version.
+    if (!reactContext.hasActiveCatalystInstance()) return
+    try {
+      reactContext
+        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+        .emit(eventName, params)
+    } catch (e: Exception) {
+      // TOCTOU race: catalyst instance was alive at the check above but is
+      // being torn down by the time we call. Drop the event quietly.
+      Registry.log.error("Failed to emit $eventName: catalyst instance unavailable", e)
+    }
   }
 
   override fun getName(): String = NAME

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.4.0</string>
+  <string name="klaviyo_sdk_version_override">2.4.1</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.4.0"
+        versionName "2.4.1"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
# Description

Brings the Android bridge's `sendEvent` helper to parity with the iOS bridge by guarding against the catalyst instance being torn down between when the native SDK fires a form-lifecycle callback and when we forward it to JS. Caught by Cursor Bugbot on [PR #339](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/339#discussion_r3184462405) — confirmed real, mirrored in RN's own [AppStateModule.sendEvent fix (c4806fa)](https://github.com/facebook/react-native/commit/c4806fada6532894e2242cf31f7145d2992e3a2b).

Targeting `rel/2.4.0` for inclusion in 2.4.1.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

> Note on testing: the bug is a teardown-race, easiest to repro in dev via fast-refresh while a form is on screen. Manual repro on emulator gets noisy; the fix is small and analogous to RN's own pattern, so leaning on the verified upstream pattern instead of adding a fragile race-condition test.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Intended for **2.4.1**. 2.4.0 just shipped; this is the only fix for the patch.

## Changelog / Code Overview

`android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt` — the `sendEvent` helper used by `registerFormLifecycleHandler` previously called `reactContext.getJSModule(...).emit(...)` unconditionally:

```kotlin
private fun sendEvent(eventName: String, params: WritableMap?) {
  reactContext
    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
    .emit(eventName, params)
}
```

`getJSModule(...)` throws `java.lang.RuntimeException: Catalyst Instance has already disappeared: requested by RCTDeviceEventEmitter` when the catalyst instance is gone. Form lifecycle callbacks fire from the native Klaviyo SDK on its own schedule and can race the host Activity/Process tearing down. Production triggers:

- App backgrounded → Android low-memory pressure kills the process while a form-event callback is queued
- User taps a CTA whose deep link launches a different activity → host activity destroyed before `formCtaClicked` is forwarded
- Configuration change (rotation, locale, dark mode) destroys + recreates the host Activity

Plus dev-mode triggers (HMR, fast-refresh) which are how the bug usually surfaces during development.

iOS bridge at [`KlaviyoReactNativeSdk.mm:149-158`](https://github.com/klaviyo/klaviyo-react-native-sdk/blob/rel/2.4.0/ios/KlaviyoReactNativeSdk.mm#L149-L158) already guards via `__weak`/`__strong` self pattern. Android brought to parity:

```kotlin
private fun sendEvent(eventName: String, params: WritableMap?) {
  if (!reactContext.hasActiveCatalystInstance()) return
  try {
    reactContext
      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
      .emit(eventName, params)
  } catch (e: Exception) {
    // TOCTOU race: alive at check, gone by call.
    Registry.log.error("Failed to emit $eventName: catalyst instance unavailable", e)
  }
}
```

Two-layer guard:

1. **`hasActiveCatalystInstance()` check** — short-circuit when the instance is already known dead. Using the deprecated alias rather than the newer `hasActiveReactInstance()` because the SDK's `peerDependencies` allow any RN version, and the deprecated method is still present on modern RN (verified against RN 0.81.5: both methods are declared on `ReactContext`).
2. **try/catch around the call** — handles the TOCTOU window where the instance is alive at the check but gets torn down before the emit completes. Logs via `Registry.log.error` so the failure is observable in the existing native SDK log stream rather than swallowed silently.

## Test Plan

- [x] `compileDebugKotlin` against the example app builds clean (`./gradlew :klaviyo-react-native-sdk:compileDebugKotlin`).
- [ ] Manually verify in dev: with a form visible, trigger fast-refresh and confirm no `Catalyst Instance has already disappeared` crash in logcat.
- [ ] Manually verify on emulator: with a form visible, force-stop the example app and reopen — no crash logged.

## Sister-platform check

Did a parallel review of the Flutter SDK Android side ([klaviyo-flutter-sdk](https://github.com/klaviyo/klaviyo-flutter-sdk)) — Flutter avoids this class of bug for free via its `EventChannel`/`EventSink` idiom: `eventSink` is a nullable field, set to null in `onCancel`, and all emits use Kotlin null-safe `eventSink?.success(...)`. Different framework, different idiom, equivalent safety. No Flutter parallel patch needed.

## Related Issues/Tickets

Bug surfaced by Cursor Bugbot on [PR #339](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/339#discussion_r3184462405) which was reviewing the form lifecycle bridge. Slipped past earlier review on [#338](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/338) plausibly because this is the SDK's first long-lived native callback that emits events — every other bridge method is JS-initiated (catalyst is alive by construction).

Part of MAGE-452 (2.4.0 release; this is the 2.4.1 patch).