### PR TITLE
docs(forms): add form lifecycle events section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,22 +624,16 @@ import { Klaviyo, FormLifecycleEventType } from 'klaviyo-react-native-sdk';
 const unsubscribe = Klaviyo.registerFormLifecycleHandler((event) => {
   switch (event.type) {
     case FormLifecycleEventType.Shown:
-      // Fires when the SDK presents a form to the user.
       console.log(`Form shown — id: ${event.formId}, name: ${event.formName}`);
       break;
 
     case FormLifecycleEventType.Dismissed:
-      // Fires only on user-initiated dismissals (e.g. tapping outside the form
-      // or pressing the close button). Does NOT fire when the SDK tears down a
-      // form internally (session timeout, programmatic unregister).
       console.log(
         `Form dismissed — id: ${event.formId}, name: ${event.formName}`
       );
       break;
 
     case FormLifecycleEventType.CtaClicked:
-      // Fires only when the tapped CTA button has a deep link URL configured.
-      // Not emitted for CTA buttons without a deep link.
       console.log(
         `CTA clicked — id: ${event.formId}, name: ${event.formName}, ` +
           `button: ${event.buttonLabel}, url: ${event.deepLinkUrl}`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
     - [Setup](#setup-1)
       - [In-App Forms Session Configuration](#in-app-forms-session-configuration)
     - [Unregistering from In-App Forms](#unregistering-from-in-app-forms)
+    - [Monitoring Form Lifecycle Events](#monitoring-form-lifecycle-events)
 
   - [Geofencing](#geofencing)
     - [Prerequisites](#prerequisites-2)
@@ -605,6 +606,53 @@ Klaviyo.unregisterFromInAppForms(config);
 ```
 
 Note that after unregistering, the next call to `registerForInAppForms()` will be considered a new session by the SDK.
+
+### Monitoring Form Lifecycle Events
+
+> Form lifecycle events are available in SDK version 2.4.0 and higher.
+
+- [Android](https://github.com/klaviyo/klaviyo-android-sdk#monitoring-form-lifecycle-events)
+- [iOS](https://github.com/klaviyo/klaviyo-swift-sdk#monitoring-form-lifecycle-events)
+
+The SDK can notify your app when key form interactions occur, which is useful for forwarding engagement data to third-party analytics platforms like Amplitude, Segment, or Mixpanel.
+
+To subscribe, call `Klaviyo.registerFormLifecycleHandler` with a callback. The function returns an unsubscribe handle — call it when you no longer need events (e.g. on component unmount or user logout).
+
+```typescript
+import { Klaviyo, FormLifecycleEventType } from 'klaviyo-react-native-sdk';
+
+const unsubscribe = Klaviyo.registerFormLifecycleHandler((event) => {
+  switch (event.type) {
+    case FormLifecycleEventType.Shown:
+      // Fires when the SDK presents a form to the user.
+      console.log(`Form shown — id: ${event.formId}, name: ${event.formName}`);
+      break;
+
+    case FormLifecycleEventType.Dismissed:
+      // Fires only on user-initiated dismissals (e.g. tapping outside the form
+      // or pressing the close button). Does NOT fire when the SDK tears down a
+      // form internally (session timeout, programmatic unregister).
+      console.log(
+        `Form dismissed — id: ${event.formId}, name: ${event.formName}`
+      );
+      break;
+
+    case FormLifecycleEventType.CtaClicked:
+      // Fires only when the tapped CTA button has a deep link URL configured.
+      // Not emitted for CTA buttons without a deep link.
+      console.log(
+        `CTA clicked — id: ${event.formId}, name: ${event.formName}, ` +
+          `button: ${event.buttonLabel}, url: ${event.deepLinkUrl}`
+      );
+      break;
+  }
+});
+
+// Later, when you no longer need events:
+unsubscribe();
+```
+
+The handler is invoked on the JavaScript thread. Only one handler can be active at a time — calling `registerFormLifecycleHandler` a second time automatically removes the previous subscription before registering the new one.
 
 ## Geofencing
 


### PR DESCRIPTION
# Description

Adds a new `Monitoring Form Lifecycle Events` section to the README documenting the public `registerFormLifecycleHandler` API shipped in 2.4.0. Mirrors (in spirit) the iOS SDK's [README PR #517](https://github.com/klaviyo/klaviyo-swift-sdk/pull/517) — the cross-platform companion — but corrects the factual issues I flagged on that iOS PR (treating non-optionals as optional, misrepresenting dismissal semantics).

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — README only. Snippet was verified by reading `src/Forms.ts` verbatim and confirmed against the example app wiring from #350. TypeScript `yarn typecheck` passes clean.
- [x] I have added sufficient unit/integration tests of my changes.
  - N/A — docs only. The bridge itself is covered by tests added in #334/#338.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
  - N/A
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - Feature parity is enforced by the bridge PRs. See parity quirks under "Code Overview" below.

## Release/Versioning Considerations

- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Merging to `rel/2.4.0` per template guidance so docs go live only with the 2.4.0 release.
- [x] This is planned work for an upcoming release.
  - Targets the **2.4.0** release, which is when `registerFormLifecycleHandler` first ships.

## Changelog / Code Overview

**What:** New `### Monitoring Form Lifecycle Events` subsection under `## In-App Forms`, plus a TOC entry. README-only change (48 insertions).

**API documented (verbatim from `src/Forms.ts` + `src/index.tsx`):**
- `Klaviyo.registerFormLifecycleHandler(handler: FormLifecycleHandler): () => void` — returns an unsubscribe function
- `FormLifecycleEvent` is a discriminated union with discriminator field `type` (the value-side `FormLifecycleEventType` const provides typed string constants `Shown` / `Dismissed` / `CtaClicked`)
- Each variant's payload (all fields are `string`, all required by validation):
  - `Shown` / `Dismissed`: `formId`, `formName`
  - `CtaClicked`: `formId`, `formName`, `buttonLabel`, `deepLinkUrl`

**Behavioral notes that match `parseFormLifecycleEvent` validation in source:**
- `formDismissed` fires only on user-initiated dismissal — not for SDK-internal teardowns (session timeout, programmatic unregister)
- `formCtaClicked` fires only when the CTA has a deep link URL configured
- The handler is invoked on the JS thread (`NativeEventEmitter` semantics)
- Re-registering automatically replaces the previous subscription (per `activeLifecycleSubscription` logic in `index.tsx`)

**Cross-platform parity quirks worth noting:**
- The discriminator field is `type` on RN, but iOS uses Swift enum `case` payloads. The TS surface intentionally diverges from a literal port of the iOS enum.
- `deepLinkUrl` is serialized as a plain `string` on the RN bridge (matching how it crosses the bridge from both Android and iOS native). iOS-native exposes a `URL` value type; the RN snippet documents the wire format the JS side actually receives.
- Android exposes the same fields with the same names, so the cross-platform reference links in the README point at the existing Android/iOS native READMEs for native-layer details.

## Test Plan

- `yarn typecheck` passes clean against the (unchanged) source.
- The example app's `useForms` hook (added in #350) already exercises this exact API surface — the README snippet is a minimal distillation of that working integration.
- Visual: rendered the new section in the markdown preview, confirmed TOC anchor, cross-platform links, and code block formatting (prettier auto-formatted to repo style).

## Related Issues/Tickets

- iOS cross-platform companion: [klaviyo/klaviyo-swift-sdk#517](https://github.com/klaviyo/klaviyo-swift-sdk/pull/517) — Evan flagged factual bugs in that PR's review (non-optionals treated as optional, dismissal semantics misrepresented); those bugs are **not** propagated to this RN doc.
- Bridge feature PRs: #334, #338
- Discriminated-union refactor: #329
- Example-app wiring (source of the verified snippet): #350