### PR TITLE
fix(android): declare KlaviyoPushService in SDK manifest for FCM coexistence

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -2,6 +2,50 @@
 
 ## Android Troubleshooting
 
+### Push notifications not displaying when another push SDK is installed
+
+On Android, Klaviyo receives push through a `FirebaseMessagingService` (`KlaviyoPushService`) registered for the
+`com.google.firebase.MESSAGING_EVENT` intent. Android delivers each FCM message to only one such service. If your
+app also includes another library that registers its own `FirebaseMessagingService` — for example
+[`@react-native-firebase/messaging`](https://www.npmjs.com/package/@react-native-firebase/messaging) or another
+third-party push SDK — only one of those services will receive a given message; the other is not invoked, so its
+notifications silently do not display (no error is logged). If Klaviyo notifications do not appear while another
+push library is installed, this is the likely cause.
+
+The Klaviyo SDK declares `KlaviyoPushService` from its own module so that it takes precedence in most setups, but
+that is not guaranteed — which service takes precedence is determined at build time by Android manifest merge order,
+which among libraries follows React Native autolinking order. Use whichever option fits your app — options 1 and 2
+make Klaviyo's service take precedence (option 1 is the most reliable), while option 3 lets both SDKs receive their
+own messages:
+
+1. **Declare `KlaviyoPushService` in your app's `AndroidManifest.xml`.** A declaration in your app's own manifest
+   always takes precedence over one contributed by a library, regardless of dependency order. This is the most
+   reliable option, and is what the [Klaviyo Expo plugin](https://github.com/klaviyo/klaviyo-expo-plugin) does
+   automatically:
+
+   ```xml
+   <!-- android/app/src/main/AndroidManifest.xml, inside the <application> element -->
+   <service
+       android:name="com.klaviyo.pushFcm.KlaviyoPushService"
+       android:exported="false">
+       <intent-filter>
+           <action android:name="com.google.firebase.MESSAGING_EVENT" />
+       </intent-filter>
+   </service>
+   ```
+
+2. **List `klaviyo-react-native-sdk` before the other push library in your `package.json` `dependencies`.**
+   React Native autolinking preserves dependency order, so listing Klaviyo first registers its service ahead of the
+   other library's. This is lighter-weight but more fragile — tooling that alphabetizes `package.json` can undo it —
+   so prefer option 1 if you need a reliable result.
+
+3. **Implement a custom `FirebaseMessagingService` that routes to each SDK.** If you need _both_ Klaviyo and
+   another push SDK to receive their own messages (rather than one simply taking precedence), register a single
+   service in your app and route each `RemoteMessage` to the appropriate SDK (use `RemoteMessage.isKlaviyoMessage`
+   to identify Klaviyo messages). See the Android SDK's
+   [Advanced Setup](https://github.com/klaviyo/klaviyo-android-sdk#advanced-setup) for how to subclass or delegate
+   to `KlaviyoPushService`.
+
 ### `minSdkVersion` Issues
 
 We have seen projects, particularly on react-native versions `0.72.x` and `0.71.x`, that required a `minSdkVersion`
@@ -114,4 +158,3 @@ This might have no impact on your use case, but is something to consider when de
 ### iOS Geofencing Events not Firing
 
 The delivery of geofence events to the Klaviyo SDK requires registering for geofences in the native iOS layer in `didFinishLaunchingWithOptions`. If you only call `Klaviyo.registerGeofencing()` in the React Native layer or any later in the lifecycle, triggered enter/exit events may not get delivered in a reliable manner as the native monitoring service relies on that AppDelegate entry point.
-

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.klaviyoreactnativesdk">
+    <application>
+        <!--
+          Legacy manifest used when the consumer builds this module with AGP < 7.3
+          (supportsNamespace() == false in android/build.gradle). Mirror of the
+          KlaviyoPushService declaration in AndroidManifestNew.xml so older-AGP consumers
+          get the same FCM service-resolution benefit. Keep the two in sync. See
+          AndroidManifestNew.xml and the "Push notifications not displaying when another push SDK
+          is installed" section of Troubleshooting.md for the full rationale.
+        -->
+        <service
+            android:name="com.klaviyo.pushFcm.KlaviyoPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,2 +1,31 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!--
+          Declare KlaviyoPushService at the SDK (library) level so it merges into the host app
+          from this module rather than only from the transitive push-fcm AAR. The direct module
+          merges earlier than its own transitive dependency, which raises the likelihood that
+          Klaviyo wins FCM service resolution when another FirebaseMessagingService-based library
+          (e.g. @react-native-firebase/messaging) is also present.
+
+          This is NOT a guarantee: Android delivers each FCM message to only one
+          FirebaseMessagingService, and among libraries the winner follows autolinking/dependency
+          order. For a guaranteed outcome, declare KlaviyoPushService in the app's own
+          AndroidManifest.xml (an app-level declaration always wins). See the "Push notifications
+          not displaying when another push SDK is installed" section of Troubleshooting.md for details.
+
+          Note: this file is the manifest source only when the consumer builds with AGP >= 7.3
+          (see supportsNamespace() in android/build.gradle). The legacy AndroidManifest.xml carries
+          a mirror of this declaration for older-AGP builds — keep the two in sync.
+
+          push-fcm is a required dependency of this SDK, so KlaviyoPushService is always on the
+          classpath and this declaration is safe.
+        -->
+        <service
+            android:name="com.klaviyo.pushFcm.KlaviyoPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>


### PR DESCRIPTION
# Description

On Android, Klaviyo receives push via a `FirebaseMessagingService` (`KlaviyoPushService`). Android delivers each FCM message to only **one** such service, so when a host app also includes another `FirebaseMessagingService`-based library (commonly `@react-native-firebase/messaging`), Klaviyo can silently lose and its notifications never display. This declares `KlaviyoPushService` from the SDK module's own manifest to win by default in most setups, and documents how to guarantee it.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - Verified the Android manifest merge via `:app:processDebugMainManifest` (blame confirms `KlaviyoPushService` now `MERGED from [:klaviyo-react-native-sdk]`, i.e. the live `AndroidManifestNew.xml`). Full on-device push E2E with a competing push SDK not run in this session — see Test Plan.
- [ ] I have added sufficient unit/integration tests of my changes.
  - N/A — manifest declaration + docs only; no testable code paths added.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [ ] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - Android-specific: this is an FCM service-resolution concern with no iOS analogue (APNs delivery differs).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Per template guidance, the reviewer/release owner may want to retarget this to a release feature branch so the README/Troubleshooting updates only go live on the next official release.
- [ ] This is planned work for an upcoming release.

## Changelog / Code Overview

- **`android/src/main/AndroidManifestNew.xml`** — declare `KlaviyoPushService` (`com.google.firebase.MESSAGING_EVENT`, no `android:priority`) from the SDK module. Previously the service was contributed only by the transitive `push-fcm` AAR, which merges late and can lose to other libraries' services. Declaring it from this direct module moves it to an earlier merge position, raising the likelihood Klaviyo wins. `push-fcm` is a mandatory `api` dependency, so the class is always on the classpath. **This is not a guarantee** — among libraries the winner follows React Native autolinking order; only an app-manifest declaration always wins.
- **`README.md`** — new "Receiving Push Notifications → Android: notifications not displaying alongside another push SDK" troubleshooting subsection (+ TOC entry): explains the single-winner contention, the guaranteed app-manifest fix (what the Klaviyo Expo plugin does automatically), the lighter `package.json`-ordering lever, and the delegating-service pattern for apps that need both SDKs to receive their own messages.
- **`Troubleshooting.md`** — short Android entry pointing to the README section.

## Test Plan

On a device/emulator with both `klaviyo-react-native-sdk` and `@react-native-firebase/messaging` installed:
1. Without any app-manifest declaration, send a Klaviyo push (via the push notification preview) and confirm it displays.
2. Send a non-Klaviyo FCM message and confirm the other SDK still handles it as expected.
3. Verify behavior holds across dependency orderings; and that adding the app-manifest declaration (README option 1) makes Klaviyo win deterministically.

## Related Issues/Tickets

- Part of MAGE-709
- Related to MAGE-708 (long-term BroadcastReceiver-based reception)
