### PR TITLE
ci: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,8 +17,3 @@ reviews:
       config_file: ".swiftlint.yml"
     eslint:
       enabled: true
-
-  path_instructions:
-    - path: "**"
-      instructions: |
-        For context on this project, review `/AGENTS.md`.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,3 +17,8 @@ reviews:
       config_file: ".swiftlint.yml"
     eslint:
       enabled: true
+
+  path_instructions:
+    - path: "**"
+      instructions: |
+        For context on this project, review `/AGENTS.md`.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+reviews:
+  profile: assertive
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/lib/**"
+    - "!**/build/**"
+    - "!**/Pods/**"
+    - "!**/*.xcodeproj/**"
+    - "!**/yarn.lock"
+    - "!example/**"
+  auto_review:
+    drafts: false
+    base_branches:
+      - ".*"
+  tools:
+    swiftlint:
+      enabled: true
+      config_file: ".swiftlint.yml"
+    eslint:
+      enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,7 +7,6 @@ reviews:
     - "!**/Pods/**"
     - "!**/*.xcodeproj/**"
     - "!**/yarn.lock"
-    - "!example/**"
   auto_review:
     drafts: false
     base_branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,3 +104,9 @@ native Android and iOS SDKs. Essential for testing changes across all three SDKs
 If prompted to create a pull request, favor starting it in draft unless asked otherwise.
 You **MUST** follow the pull request template used by this repository, including important details
 in the relevant subsections of the template.
+
+## Code Review
+
+CodeRabbit is active on this repo and auto-reviews PRs. It reads this file as a code guidelines
+source. When performing code reviews, avoid re-surfacing findings CodeRabbit may have already flagged.
+If you notice patterns worth encoding as review guidance, suggest adding them to `.coderabbit.yaml`.


### PR DESCRIPTION
Mirrors klaviyo-swift-sdk#597 for this repo.

- Adds `.coderabbit.yaml` — `profile: assertive`, no draft auto-review, all base branches; `path_filters` exclude node_modules, build outputs (`lib/`, `build/`), CocoaPods/Xcode artifacts, `yarn.lock`, and the `example/` app.
- `tools`: swiftlint (native iOS bridge, `.swiftlint.yml`) + eslint (TypeScript).
- Adds a `Code Review` section to AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration settings including refined review profiles, optimized path management, specific directory exclusions, and integrated development tool support for comprehensive and streamlined automated code review workflows

* **Documentation**
  * Added and enhanced developer collaboration guidelines for code review processes, recurring patterns, and engineering best practices for the development team

<!-- end of auto-generated comment: release notes by coderabbit.ai -->