### PR TITLE
ci: include xcodeproj files in CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,6 @@ reviews:
     - "!**/lib/**"
     - "!**/build/**"
     - "!**/Pods/**"
-    - "!**/*.xcodeproj/**"
     - "!**/yarn.lock"
   auto_review:
     drafts: false


### PR DESCRIPTION
## Summary
- Removes the `**/*.xcodeproj/**` path filter from `.coderabbit.yaml` so CodeRabbit reviews changes to the Xcode project and can catch silly mistakes there.

Mirrors the same change across the mobile SDK repos (expo klaviyo/klaviyo-expo-plugin#118, flutter klaviyo/klaviyo-flutter-sdk#104, swift klaviyo/klaviyo-swift-sdk#607), prompted by review feedback that CodeRabbit should review the Xcode project rather than skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to adjust file filtering patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->