### PR TITLE
Re-introduce registerDeepLinkHandler to avoid iOS universal-link anti-loop (PUSH-831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to the Klaviyo React Native SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+For releases prior to 2.5.0, see the
+[GitHub Releases](https://github.com/klaviyo/klaviyo-react-native-sdk/releases) page.
+
+## [2.5.0] - Unreleased
+
+### Added
+
+- `Klaviyo.registerDeepLinkHandler(handler)` — register a consumer-side handler that
+  receives the resolved destination URL of any deep link the SDK opens (push deep links,
+  In-App Form CTAs, and resolved universal tracking links). Returns an unsubscribe
+  function. When a handler is registered, the native SDK delivers the resolved URL to it
+  instead of opening the URL itself. This lets apps take full control of navigation and,
+  on iOS, avoids Apple's universal-link anti-loop protection that otherwise sends users
+  to Safari when the SDK opens a universal link on the app's own associated domain
+  ([PUSH-831](https://linear.app/klaviyo/issue/PUSH-831)). Available on both iOS and
+  Android. ([#270](https://github.com/klaviyo/klaviyo-react-native-sdk/pull/270) had
+  previously removed an earlier version of this API; this re-introduces it with a
+  cleaner subscription model.)
+
+### Notes
+
+- This is a backward-compatible change. Existing `handleUniversalTrackingLink`
+  integrations continue to work unchanged: when no deep link handler is registered, the
+  SDK falls back to its default link-opening behavior.

--- a/README.md
+++ b/README.md
@@ -513,6 +513,59 @@ The `Klaviyo.handleUniversalTrackingLink()` method will:
 
 If the link is not a Klaviyo tracking link, you should handle it as a regular deep link in your app.
 
+##### Taking Control of Resolved Deep Link Navigation
+
+> The `registerDeepLinkHandler` API is available in SDK version 2.5.0 and higher.
+
+By default, after `handleUniversalTrackingLink()` resolves a tracking link, the SDK
+opens the resolved destination URL for you. On iOS this uses `UIApplication.open(_:)`.
+**If your destination URL is itself a universal link on your own app's associated
+domain, iOS will refuse to reopen your app and will send the user to Safari instead.**
+This is Apple's anti-loop protection for auto-triggered universal links, and it cannot
+be worked around through `Linking` alone.
+
+To avoid this, register a deep link handler. When a handler is registered, the SDK
+delivers the **resolved destination URL** directly to your JavaScript code instead of
+opening it itself — for push notification deep links, In-App Form CTAs, and resolved
+universal tracking links alike. You then navigate however your app prefers (e.g. with
+React Navigation), keeping the user inside the app.
+
+```typescript
+import { useEffect } from 'react';
+import { Klaviyo } from 'klaviyo-react-native-sdk';
+
+export default function App() {
+  useEffect(() => {
+    // Register first, so resolved links are delivered here instead of being
+    // opened by the SDK. Returns an unsubscribe function.
+    const unsubscribe = Klaviyo.registerDeepLinkHandler((url) => {
+      console.log('Klaviyo resolved deep link:', url);
+      // Take full control of navigation, e.g.:
+      // navigationRef.navigate(parseUrl(url));
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  // Rest of your app code
+}
+```
+
+Notes:
+
+- The handler receives the resolved destination URL as a string.
+- The handler is invoked on the JavaScript thread.
+- Only one handler can be active at a time — calling `registerDeepLinkHandler` again
+  removes the previous subscription before registering the new one.
+- When no handler is registered, the SDK falls back to its default link-opening
+  behavior, so existing `handleUniversalTrackingLink` integrations keep working
+  unchanged.
+- This API is available on both iOS and Android for parity. Android is not affected by
+  the iOS universal-link anti-loop, but registering a handler still lets you centralize
+  navigation for all Klaviyo deep links.
+
 #### Silent Push Notifications
 
 Silent push notifications (also known as background pushes) allow your app to receive payloads from Klaviyo without displaying a visible alert to the user. These are typically used to trigger background behavior, such as displaying content, personalizing the app interface, or downloading new information from a server. To receive silent push notifications, follow the platform-specific instructions below:

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -273,6 +273,28 @@ class KlaviyoReactNativeSdkModule(
   }
 
   @ReactMethod
+  fun registerDeepLinkHandler() {
+    // When a handler is registered, the native SDK invokes it with the resolved
+    // deep link URL instead of broadcasting an Intent back to the host app. This
+    // gives consumers full control over navigation for resolved universal
+    // tracking links, keeping parity with iOS (where it also avoids the Safari
+    // universal-link anti-loop).
+    Klaviyo.registerDeepLinkHandler { uri ->
+      val params =
+        Arguments.createMap().apply {
+          putString("url", uri.toString())
+        }
+      sendEvent("KlaviyoOnDeepLinkResolved", params)
+    }
+  }
+
+  @ReactMethod
+  fun unregisterDeepLinkHandler() {
+    // Reverts the SDK to its default behavior of broadcasting a deep link Intent.
+    Klaviyo.unregisterDeepLinkHandler()
+  }
+
+  @ReactMethod
   fun createEvent(event: ReadableMap) {
     val metric =
       event

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -77,10 +77,25 @@ export default function App() {
   const [settingsVisible, setSettingsVisible] = useState(false);
 
   useEffect(() => {
+    // Register a Klaviyo deep link handler. When registered, Klaviyo delivers
+    // the *resolved* destination URL of any deep link it opens — push deep
+    // links, In-App Form CTAs, and resolved universal tracking links — directly
+    // here, instead of opening it itself. This is the recommended approach when
+    // your destination URLs are universal links on your own associated domain:
+    // on iOS, letting the SDK open a self-owned universal link triggers Apple's
+    // anti-loop protection and bounces the user out to Safari. Taking control of
+    // navigation here avoids that. The returned function unsubscribes.
+    const unsubscribeDeepLink = Klaviyo.registerDeepLinkHandler((url) => {
+      console.log('[App] Klaviyo resolved deep link:', url);
+      // Route however your app navigates, e.g. with React Navigation:
+      // navigationRef.navigate(parseUrl(url));
+    });
+
     // Deep linking handler
     const handleUrl = (url: string) => {
       if (Klaviyo.handleUniversalTrackingLink(url)) {
-        // Klaviyo is handling a universal click tracking link
+        // Klaviyo is handling a universal click tracking link. The resolved
+        // destination URL will be delivered to the deep link handler above.
         console.log('[App] Klaviyo tracking link:', url);
         return;
       }
@@ -99,7 +114,10 @@ export default function App() {
 
     // Listen for deep link events while the app is running; return cleanup to prevent listener leak
     const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url));
-    return () => sub.remove();
+    return () => {
+      sub.remove();
+      unsubscribeDeepLink();
+    };
   }, []);
 
   return (

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -266,6 +266,24 @@ public class KlaviyoBridge: NSObject {
     }
 
     @objc
+    public static func registerDeepLinkHandler(callback: @escaping ([String: Any]) -> Void) {
+        // When a custom handler is registered, the Swift SDK invokes it with the
+        // resolved deep link URL instead of calling its default URL opener. This
+        // is what lets consumers avoid iOS's universal-link anti-loop, which
+        // sends the user to Safari when the SDK opens a universal link on the
+        // app's own associated domain.
+        KlaviyoSDK().registerDeepLinkHandler { url in
+            callback(["url": url.absoluteString])
+        }
+    }
+
+    @objc
+    public static func unregisterDeepLinkHandler() {
+        // Reverts the SDK to its default link-opening behavior.
+        KlaviyoSDK().unregisterDeepLinkHandler()
+    }
+
+    @objc
     public static func createEvent(event: [String: AnyObject]) {
         guard let name = event["name"] as? String,
               !name.isEmpty,

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"FormLifecycleEvent"];
+    return @[@"FormLifecycleEvent", @"KlaviyoOnDeepLinkResolved"];
 }
 
 // The values here eventually should come from the iOS SDK once exposed there.
@@ -107,6 +107,20 @@ RCT_EXPORT_METHOD(handleUniversalTrackingLink: (NSString *)trackingLinkString)
     }
     
     [KlaviyoBridge handleUniversalTrackingLink:trackingLink];
+}
+
+RCT_EXPORT_METHOD(registerDeepLinkHandler) {
+    __weak __typeof__(self) weakSelf = self;
+    [KlaviyoBridge registerDeepLinkHandlerWithCallback:^(NSDictionary *eventData) {
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            [strongSelf sendEventWithName:@"KlaviyoOnDeepLinkResolved" body:eventData];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(unregisterDeepLinkHandler) {
+    [KlaviyoBridge unregisterDeepLinkHandler];
 }
 
 RCT_EXPORT_METHOD(createEvent: (NSDictionary *) event)

--- a/src/KlaviyoDeepLinkAPI.ts
+++ b/src/KlaviyoDeepLinkAPI.ts
@@ -1,4 +1,20 @@
 /**
+ * A handler that receives a resolved deep link URL.
+ *
+ * @param url - The resolved destination URL, as a string.
+ */
+export type DeepLinkHandler = (url: string) => void;
+
+/**
+ * The event name emitted by the native bridge when the SDK resolves a deep
+ * link (push notification deep link, In-App Form CTA, or universal tracking
+ * link). Exposed for testing; consumers should use
+ * {@link KlaviyoDeepLinkAPI#registerDeepLinkHandler} instead of subscribing to
+ * this event directly.
+ */
+export const DEEP_LINK_RESOLVED_EVENT = 'KlaviyoOnDeepLinkResolved';
+
+/**
  * Klaviyo Deep Link API
  */
 export interface KlaviyoDeepLinkAPI {
@@ -13,4 +29,40 @@ export interface KlaviyoDeepLinkAPI {
    * @returns {boolean} - Whether the link was handled successfully
    */
   handleUniversalTrackingLink(trackingLink: string | null): boolean;
+
+  /**
+   * Registers a handler that receives the resolved destination URL whenever the
+   * Klaviyo SDK opens a deep link — including push notification deep links,
+   * In-App Form CTAs, and {@link KlaviyoDeepLinkAPI#handleUniversalTrackingLink}
+   * resolutions.
+   *
+   * When a handler is registered, the native SDK delivers the resolved URL to
+   * it **instead of** invoking the platform's default URL opener. This is the
+   * recommended approach when your tracking links resolve to destinations on
+   * your own app's associated domain (i.e. your own universal links): on iOS,
+   * letting the SDK call `UIApplication.open(_:)` on a self-owned universal link
+   * triggers Apple's anti-loop protection and bounces the user out to Safari.
+   * Taking control of navigation here avoids that.
+   *
+   * Only one handler can be active at a time — calling this a second time
+   * removes the previous subscription before registering the new one. When no
+   * handler is registered, the SDK falls back to its default link-opening
+   * behavior, so existing {@link KlaviyoDeepLinkAPI#handleUniversalTrackingLink}
+   * integrations continue to work unchanged.
+   *
+   * @param handler - Function invoked with the resolved destination URL.
+   * @returns A function that unsubscribes the handler when called.
+   *
+   * @example
+   * ```typescript
+   * const unsubscribe = Klaviyo.registerDeepLinkHandler((url) => {
+   *   // Take full control of navigation, e.g. with React Navigation:
+   *   navigationRef.navigate(parseUrl(url));
+   * });
+   *
+   * // Later, when you no longer need the handler:
+   * unsubscribe();
+   * ```
+   */
+  registerDeepLinkHandler(handler: DeepLinkHandler): () => void;
 }

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -34,6 +34,8 @@ jest.mock('react-native', () => {
         unregisterGeofencing: jest.fn(),
         getCurrentGeofences: jest.fn(),
         handleUniversalTrackingLink: jest.fn(),
+        registerDeepLinkHandler: jest.fn(),
+        unregisterDeepLinkHandler: jest.fn(),
         getConstants: jest.fn().mockReturnValue({
           PROFILE_KEYS: {
             FIRST_NAME: 'first_name',
@@ -534,6 +536,138 @@ describe('Klaviyo SDK', () => {
       );
 
       // Restore console.error
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('deep link handler', () => {
+    it('should register the native handler and forward resolved deep link urls', () => {
+      const handler = jest.fn();
+      Klaviyo.registerDeepLinkHandler(handler);
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.registerDeepLinkHandler
+      ).toHaveBeenCalledTimes(1);
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', {
+        url: 'https://example.com/products/123',
+      });
+
+      expect(handler).toHaveBeenCalledWith('https://example.com/products/123');
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe and unregister the native handler when cleanup is called', () => {
+      const handler = jest.fn();
+      const unsubscribe = Klaviyo.registerDeepLinkHandler(handler);
+
+      mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterDeepLinkHandler as jest.Mock
+      ).mockClear();
+
+      unsubscribe();
+
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterDeepLinkHandler
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not forward events after unsubscribing', () => {
+      const handler = jest.fn();
+      const unsubscribe = Klaviyo.registerDeepLinkHandler(handler);
+
+      unsubscribe();
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', {
+        url: 'https://example.com/products/123',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should be safe to call the unsubscribe function more than once', () => {
+      const handler = jest.fn();
+      const unsubscribe = Klaviyo.registerDeepLinkHandler(handler);
+
+      unsubscribe();
+      expect(() => unsubscribe()).not.toThrow();
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', {
+        url: 'https://example.com/products/123',
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should clean up the previous subscription when re-registering', () => {
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+
+      Klaviyo.registerDeepLinkHandler(handler1);
+      mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterDeepLinkHandler as jest.Mock
+      ).mockClear();
+
+      // Re-registering should remove the previous listener and native handler
+      // before adding the new one.
+      Klaviyo.registerDeepLinkHandler(handler2);
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterDeepLinkHandler
+      ).toHaveBeenCalledTimes(1);
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', {
+        url: 'https://example.com/products/123',
+      });
+
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledWith('https://example.com/products/123');
+    });
+
+    it('should ignore events with a missing url', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerDeepLinkHandler(handler);
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', {});
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing or invalid url')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should ignore events with an empty string url', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerDeepLinkHandler(handler);
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', { url: '' });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing or invalid url')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should ignore events with a non-string url', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const handler = jest.fn();
+      Klaviyo.registerDeepLinkHandler(handler);
+
+      emitNativeEvent('KlaviyoOnDeepLinkResolved', { url: 42 });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('missing or invalid url')
+      );
       consoleWarnSpy.mockRestore();
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ import type { Event } from './Event';
 import type { FormConfiguration, FormLifecycleHandler } from './Forms';
 import { parseFormLifecycleEvent } from './Forms';
 import type { Geofence } from './Geofencing';
+import type { DeepLinkHandler } from './KlaviyoDeepLinkAPI';
+import { DEEP_LINK_RESOLVED_EVENT } from './KlaviyoDeepLinkAPI';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
 const FORMS_UNAVAILABLE_MESSAGE =
@@ -40,6 +42,9 @@ function isLocationAvailable(): boolean {
 
 // Track active lifecycle subscription to prevent duplicate listeners
 let activeLifecycleSubscription: { remove: () => void } | null = null;
+
+// Track active deep link subscription to prevent duplicate listeners
+let activeDeepLinkSubscription: { remove: () => void } | null = null;
 
 /**
  * Implementation of the {@link KlaviyoInterface}
@@ -141,6 +146,40 @@ export const Klaviyo: KlaviyoInterface = {
     KlaviyoReactNativeSdk.handleUniversalTrackingLink(urlStr);
     return true;
   },
+  registerDeepLinkHandler(handler: DeepLinkHandler): () => void {
+    // Clean up any existing subscription before re-registering
+    if (activeDeepLinkSubscription) {
+      activeDeepLinkSubscription.remove();
+      KlaviyoReactNativeSdk.unregisterDeepLinkHandler();
+      activeDeepLinkSubscription = null;
+    }
+
+    const eventEmitter = new NativeEventEmitter(
+      NativeModules.KlaviyoReactNativeSdk
+    );
+
+    activeDeepLinkSubscription = eventEmitter.addListener(
+      DEEP_LINK_RESOLVED_EVENT,
+      (data: { url?: unknown }) => {
+        const url = data?.url;
+        if (typeof url === 'string' && url.length > 0) {
+          handler(url);
+        } else {
+          console.warn(
+            '[Klaviyo] Ignoring deep link event with missing or invalid url'
+          );
+        }
+      }
+    );
+
+    KlaviyoReactNativeSdk.registerDeepLinkHandler();
+
+    return () => {
+      activeDeepLinkSubscription?.remove();
+      activeDeepLinkSubscription = null;
+      KlaviyoReactNativeSdk.unregisterDeepLinkHandler();
+    };
+  },
   registerFormLifecycleHandler(handler: FormLifecycleHandler): () => void {
     if (!isFormsAvailable()) return () => {};
 
@@ -190,5 +229,5 @@ export type {
   FormLifecycleEvent,
   FormLifecycleHandler,
 } from './Forms';
-export type { KlaviyoDeepLinkAPI } from './KlaviyoDeepLinkAPI';
+export type { KlaviyoDeepLinkAPI, DeepLinkHandler } from './KlaviyoDeepLinkAPI';
 export type { Geofence } from './Geofencing';


### PR DESCRIPTION
# Description

Re-introduces a consumer-side deep link handler on the RN `Klaviyo` API so apps can take full control of navigation for resolved Klaviyo deep links. This fixes [PUSH-831](https://linear.app/klaviyo/issue/PUSH-831/push-universal-tracking-opens-destination-url-in-browser-instead-of), where resolved universal tracking links open in Safari on iOS instead of the app.

## Root cause

On iOS, `handleUniversalTrackingLink` records the click, resolves the destination URL, then hands the resolved URL to the SDK's default opener (`UIApplication.open(_:)`). When that resolved URL is a **universal link on the consumer app's own associated domain**, iOS refuses to reopen the app and sends the user to Safari — Apple's anti-loop protection for auto-triggered universal links. This is not avoidable from JS via `Linking` alone.

The native Swift SDK already exposes `registerDeepLinkHandler(_:)`, which (per its docs) is "invoked **instead of** the default URL opener." The Android SDK has the same: a registered `DeepLinkHandler` takes the place of broadcasting a deep link `Intent`. The RN SDK previously had a similar API but it was removed in #270 in favor of `Linking`. That removal is what makes this case unsolvable today.

## Approach

Rather than have the RN bridge try to suppress `OpenURL` itself (it can't — that behavior lives in the native SDK), this re-exposes the native `registerDeepLinkHandler` through the bridge. Registering a handler is precisely the documented mechanism by which both native SDKs route the resolved URL to consumer code instead of the default opener. This is the root-cause-correct fix and keeps iOS/Android at parity.

The new JS API mirrors the existing `registerFormLifecycleHandler` subscription model (`NativeEventEmitter` + returned unsubscribe function), so it fits the current architecture rather than reviving the old standalone emitter module that #270 deleted.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable). — ⚠️ Not done in the authoring environment (no iOS/Android toolchain). Needs a maintainer to run the example app on a device/simulator with a self-domain universal link. See Test Plan.
- [x] I have added sufficient unit/integration tests of my changes. (Jest; see notes on native test harnesses below.)
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android.

## Release/Versioning Considerations

- [x] `Minor` Contains changes to the public API.
- [x] Contains readme or migration guide changes.
  - README changes are included; please merge to a feature branch so docs only go live on release.
- [x] This is planned work for an upcoming release.

Targeting **2.5.0** (new public API, no breaking changes). I did **not** bump `package.json`/podspec versions — the repo automates that via `bump-version.sh`/`release-it`, so I left versioning to the release process and only added a forward-looking `CHANGELOG.md` entry. Please add the `2.5.0` milestone label.

## Changelog / Code Overview

**JS / TS**
- `src/KlaviyoDeepLinkAPI.ts`: re-add `DeepLinkHandler` type; add `registerDeepLinkHandler(handler): () => void` to the interface; export the `KlaviyoOnDeepLinkResolved` event name constant.
- `src/index.tsx`: implement `registerDeepLinkHandler` (subscribe to `KlaviyoOnDeepLinkResolved`, validate payload `{ url }`, single-active-handler semantics, unsubscribe → native `unregisterDeepLinkHandler`). Export `DeepLinkHandler`.

**iOS**
- `ios/KlaviyoBridge.swift`: `registerDeepLinkHandler(callback:)` → `KlaviyoSDK().registerDeepLinkHandler { ... }`; `unregisterDeepLinkHandler()`.
- `ios/KlaviyoReactNativeSdk.mm`: add `KlaviyoOnDeepLinkResolved` to `supportedEvents`; export `registerDeepLinkHandler`/`unregisterDeepLinkHandler`, emitting the event via the existing `RCTEventEmitter`.

**Android**
- `KlaviyoReactNativeSdkModule.kt`: `registerDeepLinkHandler()` → `Klaviyo.registerDeepLinkHandler { uri -> sendEvent("KlaviyoOnDeepLinkResolved", { url }) }`; `unregisterDeepLinkHandler()`.

**Docs / example / changelog**
- `README.md`: new "Taking Control of Resolved Deep Link Navigation" subsection explaining the iOS anti-loop and recommending the handler for self-domain universal links.
- `example/src/App.tsx`: register a handler alongside the existing `Linking` flow.
- `CHANGELOG.md`: new file with a 2.5.0 entry.

**Compatibility verified:** the pinned native deps already expose the API — KlaviyoSwift `5.3.1` and klaviyo-android-sdk `4.4.0` both have `registerDeepLinkHandler`/`unregisterDeepLinkHandler`.

## Test Plan

Automated (run in authoring env):
- `yarn test` → 65 passing (includes new `deep link handler` suite: register + forward, unsubscribe, no-forward-after-unsubscribe, idempotent unsubscribe, re-register cleanup, and invalid/missing/empty/non-string url rejection).
- `yarn typecheck`, `yarn eslint` (changed TS incl. example), `yarn prettier` → clean.

Manual (needs a maintainer):
1. Configure the example app with an Associated Domain that is also the tracking link destination.
2. Register a handler via `Klaviyo.registerDeepLinkHandler`.
3. Open a Klaviyo tracking link (`https://<domain>/u/...`) resolving to a universal link on that same domain.
4. Expect: handler fires with the resolved URL and the app stays foregrounded (no Safari bounce). With the handler unregistered, confirm prior behavior is unchanged.

> ⚠️ **Native linters/builds not run here:** the authoring sandbox has no JVM/Swift toolchain, so `ktlint`, `swiftlint`, and native compilation (Gradle/Xcode) could not be executed. The Kotlin/Swift/ObjC changes mirror existing, linted patterns in the same files and use APIs confirmed present at the pinned SDK versions, but CI (or a maintainer) should run the native lint/build before merge. Likewise, the repo has no JUnit/XCTest harness for the bridge module today, so per-platform unit tests would require new infra and were intentionally not scaffolded — flagging rather than adding unverifiable test files.

## Related Issues/Tickets

- Linear: [PUSH-831](https://linear.app/klaviyo/issue/PUSH-831/push-universal-tracking-opens-destination-url-in-browser-instead-of)
- Prior art: #270 (removed `registerDeepLinkHandler`), #265 / #269 (universal link support/fixes), #273 / #274 (universal linking docs/example)

cc @klaviyo/mobile-push-team for review.

🤖 Generated with Reca