### PR TITLE
feat: bridge JWT auth token provider to native SDKs (MAGE-610)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,7 +17,8 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.4.0
+# saved: 4.4.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=de5f8703433139813a06e946bd8657ef6e3a13ce
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,8 +17,7 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-# saved: 4.4.0
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=../../klaviyo-android-sdk
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.4.0
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -33,6 +33,7 @@ import com.klaviyo.location.GeofencingProvider
 import com.klaviyo.location.LocationManager
 import com.klaviyo.location.registerGeofencing
 import com.klaviyo.location.unregisterGeofencing
+import java.io.IOException
 import java.io.Serializable
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -433,7 +434,18 @@ class KlaviyoReactNativeSdkModule(
           .takeIf { it.hasKey("error") && it.getType("error") == ReadableType.String }
           ?.getString("error")
           ?: "Auth token provider returned no token"
-      callback.onFailure(Throwable(error))
+      val isConnectivityError =
+        response.hasKey("isConnectivityError") &&
+          response.getType("isConnectivityError") == ReadableType.Boolean &&
+          response.getBoolean("isConnectivityError")
+      // Surface connectivity failures as an IOException so the SDK's
+      // connectivity-driven retry classifier recognizes them; other failures
+      // use a generic Throwable, which the SDK treats as non-retryable.
+      if (isConnectivityError) {
+        callback.onFailure(IOException(error))
+      } else {
+        callback.onFailure(Throwable(error))
+      }
     }
   }
 

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -385,6 +385,13 @@ class KlaviyoReactNativeSdkModule(
   fun registerAuthTokenProvider() {
     try {
       Klaviyo.registerAuthTokenProvider { callback ->
+        // The native SDK keeps at most one token fetch in flight, so any entries
+        // still pending when a NEW request arrives belong to a previous fetch the
+        // SDK has already abandoned (e.g. it timed out). Android's callback API
+        // gives no per-request timeout hook (unlike iOS withTaskCancellationHandler
+        // onCancel), so this is where stale ids are reclaimed — failing them here
+        // bounds the map and honors the "timed-out ids don't resolve" contract.
+        failAndDrainPendingAuthCallbacks("Superseded by a newer auth token request")
         val id = UUID.randomUUID().toString()
         pendingAuthCallbacks[id] = callback
         val emitted =
@@ -414,14 +421,20 @@ class KlaviyoReactNativeSdkModule(
       Registry.log.error("Failed to unregister auth token provider", e)
     } finally {
       // Fail and drop any requests still awaiting a JS response so no callbacks
-      // dangle after the provider is torn down. Remove-then-fail per key so a
-      // concurrent respondToAuthTokenRequest can't also resolve the same
-      // callback (preserves the callback's "invoke exactly once" contract).
-      pendingAuthCallbacks.keys.toList().forEach { id ->
-        pendingAuthCallbacks.remove(id)?.onFailure(
-          IllegalStateException("Auth token provider was unregistered"),
-        )
-      }
+      // dangle after the provider is torn down.
+      failAndDrainPendingAuthCallbacks("Auth token provider was unregistered")
+    }
+  }
+
+  /**
+   * Fails and evicts every pending auth token callback with [reason]. Uses
+   * remove-then-fail per key so a concurrent [respondToAuthTokenRequest] can't
+   * also resolve the same callback (preserves the callback's "invoke exactly
+   * once" contract).
+   */
+  private fun failAndDrainPendingAuthCallbacks(reason: String) {
+    pendingAuthCallbacks.keys.toList().forEach { id ->
+      pendingAuthCallbacks.remove(id)?.onFailure(IllegalStateException(reason))
     }
   }
 

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -400,11 +400,13 @@ class KlaviyoReactNativeSdkModule(
       Registry.log.error("Failed to unregister auth token provider", e)
     } finally {
       // Fail and drop any requests still awaiting a JS response so no callbacks
-      // dangle after the provider is torn down.
-      val abandoned = ArrayList(pendingAuthCallbacks.values)
-      pendingAuthCallbacks.clear()
-      abandoned.forEach {
-        it.onFailure(IllegalStateException("Auth token provider was unregistered"))
+      // dangle after the provider is torn down. Remove-then-fail per key so a
+      // concurrent respondToAuthTokenRequest can't also resolve the same
+      // callback (preserves the callback's "invoke exactly once" contract).
+      pendingAuthCallbacks.keys.toList().forEach { id ->
+        pendingAuthCallbacks.remove(id)?.onFailure(
+          IllegalStateException("Auth token provider was unregistered"),
+        )
       }
     }
   }

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -376,14 +376,34 @@ class KlaviyoReactNativeSdkModule(
   /**
    * Pending auth token requests keyed by correlation ID. The native SDK invokes
    * the provider on a background dispatcher and hands us a [AuthTokenProvider.Callback]
-   * to complete once the JS side responds via [respondToAuthTokenRequest]. The
-   * token itself is never logged; all token logging happens in the native SDK.
+   * to complete once the JS side responds via [respondToAuthTokenRequest]. Each
+   * entry is tagged with the registration [PendingAuthRequest.generation] it
+   * belongs to. The token itself is never logged; all token logging happens in
+   * the native SDK.
    */
-  private val pendingAuthCallbacks = ConcurrentHashMap<String, AuthTokenProvider.Callback>()
+  private val pendingAuthCallbacks = ConcurrentHashMap<String, PendingAuthRequest>()
+
+  /**
+   * Monotonic registration generation, bumped on every register and unregister
+   * (both on the main/bridge thread). A pending request carries the generation
+   * captured when its provider was registered; if that no longer matches
+   * [authTokenGeneration] at response time, the provider was torn down or
+   * replaced while the request was in flight, and the request is failed rather
+   * than answered with a different registration's token.
+   */
+  private var authTokenGeneration = 0
+
+  private data class PendingAuthRequest(
+    val callback: AuthTokenProvider.Callback,
+    val generation: Int,
+  )
 
   @ReactMethod
   fun registerAuthTokenProvider() {
     try {
+      // Capture this registration's generation now; the lambda closes over it
+      // by value, so it never races on shared state from the SDK's dispatcher.
+      val generation = ++authTokenGeneration
       Klaviyo.registerAuthTokenProvider { callback ->
         // The native SDK keeps at most one token fetch in flight, so any entries
         // still pending when a NEW request arrives belong to a previous fetch the
@@ -393,7 +413,7 @@ class KlaviyoReactNativeSdkModule(
         // bounds the map and honors the "timed-out ids don't resolve" contract.
         failAndDrainPendingAuthCallbacks("Superseded by a newer auth token request")
         val id = UUID.randomUUID().toString()
-        pendingAuthCallbacks[id] = callback
+        pendingAuthCallbacks[id] = PendingAuthRequest(callback, generation)
         val emitted =
           sendEvent(
             "klaviyo:authTokenRequested",
@@ -403,7 +423,7 @@ class KlaviyoReactNativeSdkModule(
           // The JS bridge is unavailable (catalyst torn down), so no response
           // will ever arrive. Fail fast instead of leaving the callback pending
           // until the native SDK's timeout, and don't leak the map entry.
-          pendingAuthCallbacks.remove(id)?.onFailure(
+          pendingAuthCallbacks.remove(id)?.callback?.onFailure(
             IllegalStateException("Unable to reach the JS auth token provider (bridge unavailable)"),
           )
         }
@@ -420,8 +440,10 @@ class KlaviyoReactNativeSdkModule(
     } catch (e: Exception) {
       Registry.log.error("Failed to unregister auth token provider", e)
     } finally {
-      // Fail and drop any requests still awaiting a JS response so no callbacks
-      // dangle after the provider is torn down.
+      // Bump the generation so any request stored by an in-flight provider
+      // callback that races this teardown is treated as stale at response time,
+      // then fail and drop any requests still awaiting a JS response.
+      ++authTokenGeneration
       failAndDrainPendingAuthCallbacks("Auth token provider was unregistered")
     }
   }
@@ -434,7 +456,7 @@ class KlaviyoReactNativeSdkModule(
    */
   private fun failAndDrainPendingAuthCallbacks(reason: String) {
     pendingAuthCallbacks.keys.toList().forEach { id ->
-      pendingAuthCallbacks.remove(id)?.onFailure(IllegalStateException(reason))
+      pendingAuthCallbacks.remove(id)?.callback?.onFailure(IllegalStateException(reason))
     }
   }
 
@@ -443,13 +465,24 @@ class KlaviyoReactNativeSdkModule(
     id: String,
     response: ReadableMap,
   ) {
-    val callback = pendingAuthCallbacks.remove(id)
-    if (callback == null) {
+    val pending = pendingAuthCallbacks.remove(id)
+    if (pending == null) {
       // Unknown, already-resolved, or timed-out request. Nothing to do.
       Registry.log.verbose("No pending auth token request for id $id")
       return
     }
 
+    if (pending.generation != authTokenGeneration) {
+      // The provider was unregistered/replaced while this request was in flight,
+      // so it belongs to a superseded registration. Fail it rather than answer
+      // it with a different registration's token.
+      pending.callback.onFailure(
+        IllegalStateException("Auth token request superseded by re-registration"),
+      )
+      return
+    }
+
+    val callback = pending.callback
     val jwt =
       response
         .takeIf { it.hasKey("jwt") && it.getType("jwt") == ReadableType.String }

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -52,7 +52,7 @@ class KlaviyoReactNativeSdkModule(
   private fun sendEvent(
     eventName: String,
     params: WritableMap?,
-  ) {
+  ): Boolean {
     // Form lifecycle callbacks fire from the native SDK and can race the
     // host Activity/Process being torn down (background → low-memory kill,
     // config change, deep-link launch from CTA, dev-mode HMR/fast-refresh).
@@ -62,15 +62,20 @@ class KlaviyoReactNativeSdkModule(
     // Using `hasActiveCatalystInstance` (deprecated alias of
     // `hasActiveReactInstance`) for broader peer-dep range — the SDK's
     // peerDependencies allow any react-native version.
-    if (!reactContext.hasActiveCatalystInstance()) return
-    try {
+    // Returns whether the event was actually emitted, so callers that must
+    // guarantee delivery (e.g. auth-token requests awaiting a JS response) can
+    // fail fast when the bridge is unavailable rather than hang.
+    if (!reactContext.hasActiveCatalystInstance()) return false
+    return try {
       reactContext
         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
         .emit(eventName, params)
+      true
     } catch (e: Exception) {
       // TOCTOU race: catalyst instance was alive at the check above but is
       // being torn down by the time we call. Drop the event quietly.
       Registry.log.error("Failed to emit $eventName: catalyst instance unavailable", e)
+      false
     }
   }
 
@@ -382,10 +387,19 @@ class KlaviyoReactNativeSdkModule(
       Klaviyo.registerAuthTokenProvider { callback ->
         val id = UUID.randomUUID().toString()
         pendingAuthCallbacks[id] = callback
-        sendEvent(
-          "klaviyo:authTokenRequested",
-          Arguments.createMap().apply { putString("id", id) },
-        )
+        val emitted =
+          sendEvent(
+            "klaviyo:authTokenRequested",
+            Arguments.createMap().apply { putString("id", id) },
+          )
+        if (!emitted) {
+          // The JS bridge is unavailable (catalyst torn down), so no response
+          // will ever arrive. Fail fast instead of leaving the callback pending
+          // until the native SDK's timeout, and don't leak the map entry.
+          pendingAuthCallbacks.remove(id)?.onFailure(
+            IllegalStateException("Unable to reach the JS auth token provider (bridge unavailable)"),
+          )
+        }
       }
     } catch (e: Exception) {
       Registry.log.error("Failed to register auth token provider", e)

--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -19,6 +19,7 @@ import com.klaviyo.analytics.model.Profile
 import com.klaviyo.analytics.model.ProfileKey
 import com.klaviyo.core.MissingKlaviyoModule
 import com.klaviyo.core.Registry
+import com.klaviyo.core.auth.AuthTokenProvider
 import com.klaviyo.core.config.Config
 import com.klaviyo.core.utils.AdvancedAPI
 import com.klaviyo.forms.FormLifecycleEvent
@@ -33,6 +34,8 @@ import com.klaviyo.location.LocationManager
 import com.klaviyo.location.registerGeofencing
 import com.klaviyo.location.unregisterGeofencing
 import java.io.Serializable
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KVisibility
 import kotlin.time.Duration.Companion.seconds
 
@@ -361,6 +364,76 @@ class KlaviyoReactNativeSdkModule(
       } catch (e: MissingKlaviyoModule) {
         Registry.log.error("Forms module is not available", e)
       }
+    }
+  }
+
+  /**
+   * Pending auth token requests keyed by correlation ID. The native SDK invokes
+   * the provider on a background dispatcher and hands us a [AuthTokenProvider.Callback]
+   * to complete once the JS side responds via [respondToAuthTokenRequest]. The
+   * token itself is never logged; all token logging happens in the native SDK.
+   */
+  private val pendingAuthCallbacks = ConcurrentHashMap<String, AuthTokenProvider.Callback>()
+
+  @ReactMethod
+  fun registerAuthTokenProvider() {
+    try {
+      Klaviyo.registerAuthTokenProvider { callback ->
+        val id = UUID.randomUUID().toString()
+        pendingAuthCallbacks[id] = callback
+        sendEvent(
+          "klaviyo:authTokenRequested",
+          Arguments.createMap().apply { putString("id", id) },
+        )
+      }
+    } catch (e: Exception) {
+      Registry.log.error("Failed to register auth token provider", e)
+    }
+  }
+
+  @ReactMethod
+  fun unregisterAuthTokenProvider() {
+    try {
+      Klaviyo.unregisterAuthTokenProvider()
+    } catch (e: Exception) {
+      Registry.log.error("Failed to unregister auth token provider", e)
+    } finally {
+      // Fail and drop any requests still awaiting a JS response so no callbacks
+      // dangle after the provider is torn down.
+      val abandoned = ArrayList(pendingAuthCallbacks.values)
+      pendingAuthCallbacks.clear()
+      abandoned.forEach {
+        it.onFailure(IllegalStateException("Auth token provider was unregistered"))
+      }
+    }
+  }
+
+  @ReactMethod
+  fun respondToAuthTokenRequest(
+    id: String,
+    response: ReadableMap,
+  ) {
+    val callback = pendingAuthCallbacks.remove(id)
+    if (callback == null) {
+      // Unknown, already-resolved, or timed-out request. Nothing to do.
+      Registry.log.verbose("No pending auth token request for id $id")
+      return
+    }
+
+    val jwt =
+      response
+        .takeIf { it.hasKey("jwt") && it.getType("jwt") == ReadableType.String }
+        ?.getString("jwt")
+
+    if (jwt != null) {
+      callback.onSuccess(jwt)
+    } else {
+      val error =
+        response
+          .takeIf { it.hasKey("error") && it.getType("error") == ReadableType.String }
+          ?.getString("error")
+          ?: "Auth token provider returned no token"
+      callback.onFailure(Throwable(error))
     }
   }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -39,10 +39,6 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
-  pod 'KlaviyoCore', :path => '../../../klaviyo-swift-sdk'
-  pod 'KlaviyoSwift', :path => '../../../klaviyo-swift-sdk'
-  pod 'KlaviyoForms', :path => '../../../klaviyo-swift-sdk'
-  pod 'KlaviyoLocation', :path => '../../../klaviyo-swift-sdk'
 
   # Setup permissions for react-native-permissions
   setup_permissions([
@@ -82,6 +78,6 @@ end
 target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
   # Insert override klaviyo-swift-sdk extension pod below this line when needed
-  pod 'KlaviyoSwiftExtension', :path => '../../../klaviyo-swift-sdk'
+  pod 'KlaviyoSwiftExtension'
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -39,6 +39,10 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
+  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'feat/jwts-for-personalized-forms'
+  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'feat/jwts-for-personalized-forms'
+  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'feat/jwts-for-personalized-forms'
+  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'feat/jwts-for-personalized-forms'
 
   # Setup permissions for react-native-permissions
   setup_permissions([
@@ -78,6 +82,6 @@ end
 target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
   # Insert override klaviyo-swift-sdk extension pod below this line when needed
-  pod 'KlaviyoSwiftExtension'
+  pod 'KlaviyoSwiftExtension', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'feat/jwts-for-personalized-forms'
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,10 +63,10 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.4.1):
-    - KlaviyoForms
-    - KlaviyoLocation
-    - KlaviyoSwift
+  - klaviyo-react-native-sdk (2.4.0):
+    - KlaviyoForms (= 5.3.1)
+    - KlaviyoLocation (= 5.3.1)
+    - KlaviyoSwift (= 5.3.1)
     - React-Core
   - KlaviyoCore (5.3.1):
     - AnyCodable-FlightSchool
@@ -2544,11 +2544,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
-  - KlaviyoCore (from `../../../klaviyo-swift-sdk`)
-  - KlaviyoForms (from `../../../klaviyo-swift-sdk`)
-  - KlaviyoLocation (from `../../../klaviyo-swift-sdk`)
-  - KlaviyoSwift (from `../../../klaviyo-swift-sdk`)
-  - KlaviyoSwiftExtension (from `../../../klaviyo-swift-sdk`)
+  - KlaviyoSwiftExtension
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -2632,6 +2628,11 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
+    - KlaviyoCore
+    - KlaviyoForms
+    - KlaviyoLocation
+    - KlaviyoSwift
+    - KlaviyoSwiftExtension
     - nanopb
     - PromisesObjC
     - SocketRocket
@@ -2654,16 +2655,6 @@ EXTERNAL SOURCES:
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
   klaviyo-react-native-sdk:
     :path: "../.."
-  KlaviyoCore:
-    :path: "../../../klaviyo-swift-sdk"
-  KlaviyoForms:
-    :path: "../../../klaviyo-swift-sdk"
-  KlaviyoLocation:
-    :path: "../../../klaviyo-swift-sdk"
-  KlaviyoSwift:
-    :path: "../../../klaviyo-swift-sdk"
-  KlaviyoSwiftExtension:
-    :path: "../../../klaviyo-swift-sdk"
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2820,11 +2811,11 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 2ed29cc71394d083f15b05a2e99cbbe284f6bb34
-  KlaviyoCore: ca55389d93ba15a56ca00591c3a9041259b55f4f
+  klaviyo-react-native-sdk: 021a6341807e8cbc03e595e5b499276cb115c641
+  KlaviyoCore: 37750d289e7113277899f6a2c9f8f088e732d869
   KlaviyoForms: 7e69da16880700be263b819e542255d2b639507a
   KlaviyoLocation: 07b9a74ebcef661310b22f4be6ebd0e03c816793
-  KlaviyoSwift: 08a6252cca7a59f80345a7622d7bbe69aafe5ca6
+  KlaviyoSwift: 5406447e2e594c47c80d9442c67ac088b92cc77e
   KlaviyoSwiftExtension: cf8257a28734e076224560fe7379a8eb6aa94270
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -2899,6 +2890,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: 007b996fcbf13f43773ff6b2fcd60cd0c5a41555
+PODFILE CHECKSUM: 1ab968cc8cc5357131b42b0efa05d7865588a201
 
 COCOAPODS: 1.16.2

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -145,7 +145,7 @@ public class KlaviyoBridge: NSObject {
     /// The token itself never crosses through here in a loggable form and is
     /// never logged; all token logging happens in the native SDK.
     @objc
-    public static func registerAuthTokenProvider(emit: @escaping @Sendable ([String: Any]) -> Void) {
+    public static func registerAuthTokenProvider(emit: @escaping @Sendable ([String: Any]) -> Bool) {
         KlaviyoSDK().registerAuthTokenProvider { () async throws -> String in
             let id = UUID().uuidString
             return try await withTaskCancellationHandler {
@@ -153,7 +153,17 @@ public class KlaviyoBridge: NSObject {
                     authTokenLock.lock()
                     pendingAuthTokenRequests[id] = continuation
                     authTokenLock.unlock()
-                    emit(["id": id])
+                    if !emit(["id": id]) {
+                        // The JS bridge is unavailable (module deallocated), so
+                        // no response will arrive. Fail fast instead of waiting
+                        // for the SDK timeout, and evict so nothing leaks.
+                        authTokenLock.lock()
+                        let pending = pendingAuthTokenRequests.removeValue(forKey: id)
+                        authTokenLock.unlock()
+                        pending?.resume(throwing: authTokenError(
+                            "Unable to reach the JS auth token provider (bridge unavailable)"
+                        ))
+                    }
                 }
             } onCancel: {
                 // The SDK cancels the provider task on timeout. Resolve the

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -158,6 +158,13 @@ public class KlaviyoBridge: NSObject {
             } onCancel: {
                 // The SDK cancels the provider task on timeout. Resolve the
                 // continuation with cancellation and evict it so nothing leaks.
+                //
+                // If cancellation lands in the narrow window before the
+                // operation stores the continuation, this finds nothing to
+                // remove (a safe no-op) and the operation still stores + emits
+                // afterward. That only costs a spurious `authTokenRequested`
+                // event: the SDK re-checks cancellation after the provider
+                // returns and discards the stale token before caching it.
                 authTokenLock.lock()
                 let continuation = pendingAuthTokenRequests.removeValue(forKey: id)
                 authTokenLock.unlock()

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -174,8 +174,14 @@ public class KlaviyoBridge: NSObject {
     /// Resolves a pending auth token request. Called from JS once the host
     /// provider has produced a token (`jwt`) or failed (`error`). Unknown or
     /// already-resolved IDs are ignored.
+    ///
+    /// When `isConnectivityError` is `true`, the failure is surfaced as a
+    /// `URLError` with a connectivity code so the SDK's connectivity-driven
+    /// refresh retry (which classifies via `URLError.isConnectivityError`)
+    /// recognizes it. Other failures use a generic error, which the SDK treats
+    /// as non-retryable.
     @objc
-    public static func respondToAuthTokenRequest(id: String, jwt: String?, error: String?) {
+    public static func respondToAuthTokenRequest(id: String, jwt: String?, error: String?, isConnectivityError: Bool) {
         authTokenLock.lock()
         let continuation = pendingAuthTokenRequests.removeValue(forKey: id)
         authTokenLock.unlock()
@@ -189,11 +195,18 @@ public class KlaviyoBridge: NSObject {
             continuation.resume(returning: jwt)
         } else {
             let message = error ?? "Auth token provider returned no token"
-            continuation.resume(throwing: NSError(
-                domain: "KlaviyoReactNativeSdk",
-                code: -1,
-                userInfo: [NSLocalizedDescriptionKey: message]
-            ))
+            if isConnectivityError {
+                continuation.resume(throwing: URLError(
+                    .notConnectedToInternet,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                ))
+            } else {
+                continuation.resume(throwing: NSError(
+                    domain: "KlaviyoReactNativeSdk",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                ))
+            }
         }
     }
 

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -124,6 +124,79 @@ public class KlaviyoBridge: NSObject {
         #endif
     }
 
+    // MARK: - Auth token bridging
+
+    /// Pending auth token requests keyed by correlation ID. The native SDK's
+    /// async provider closure suspends on a continuation stored here until the
+    /// JS side responds (or the request is cancelled by the SDK's timeout).
+    ///
+    /// A `CheckedContinuation` must be resumed exactly once. All access is
+    /// serialized through `authTokenLock`, and every resume path first removes
+    /// the entry from the dictionary — whichever path removes it wins and
+    /// resumes; any later path finds nothing and is a no-op.
+    private static var pendingAuthTokenRequests: [String: CheckedContinuation<String, Error>] = [:]
+    private static let authTokenLock = NSLock()
+
+    /// Registers a wrapper-owned auth token provider with the native SDK. When
+    /// the SDK invokes the provider, this generates a correlation ID, emits it
+    /// to JS via `emit`, and suspends until the JS side responds through
+    /// `respondToAuthTokenRequest(id:jwt:error:)`.
+    ///
+    /// The token itself never crosses through here in a loggable form and is
+    /// never logged; all token logging happens in the native SDK.
+    @objc
+    public static func registerAuthTokenProvider(emit: @escaping @Sendable ([String: Any]) -> Void) {
+        KlaviyoSDK().registerAuthTokenProvider { () async throws -> String in
+            let id = UUID().uuidString
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    authTokenLock.lock()
+                    pendingAuthTokenRequests[id] = continuation
+                    authTokenLock.unlock()
+                    emit(["id": id])
+                }
+            } onCancel: {
+                // The SDK cancels the provider task on timeout. Resolve the
+                // continuation with cancellation and evict it so nothing leaks.
+                authTokenLock.lock()
+                let continuation = pendingAuthTokenRequests.removeValue(forKey: id)
+                authTokenLock.unlock()
+                continuation?.resume(throwing: CancellationError())
+            }
+        }
+    }
+
+    @objc
+    public static func unregisterAuthTokenProvider() {
+        KlaviyoSDK().unregisterAuthTokenProvider()
+    }
+
+    /// Resolves a pending auth token request. Called from JS once the host
+    /// provider has produced a token (`jwt`) or failed (`error`). Unknown or
+    /// already-resolved IDs are ignored.
+    @objc
+    public static func respondToAuthTokenRequest(id: String, jwt: String?, error: String?) {
+        authTokenLock.lock()
+        let continuation = pendingAuthTokenRequests.removeValue(forKey: id)
+        authTokenLock.unlock()
+
+        guard let continuation else {
+            // Already resolved/cancelled, or never existed. Nothing to do.
+            return
+        }
+
+        if let jwt {
+            continuation.resume(returning: jwt)
+        } else {
+            let message = error ?? "Auth token provider returned no token"
+            continuation.resume(throwing: NSError(
+                domain: "KlaviyoReactNativeSdk",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            ))
+        }
+    }
+
     @MainActor
     @objc
     public static func registerGeofencing() {

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -176,6 +176,30 @@ public class KlaviyoBridge: NSObject {
     @objc
     public static func unregisterAuthTokenProvider() {
         KlaviyoSDK().unregisterAuthTokenProvider()
+        // Defense-in-depth + parity with Android: proactively fail any pending
+        // requests. The SDK's unregister cancels the in-flight fetch (which
+        // trips the `onCancel` above), but draining here doesn't rely on that
+        // cross-module behavior. The lock-guarded remove keeps resolution
+        // exactly-once — whichever path claims a continuation first wins.
+        failAllPendingAuthTokenRequests(reason: "Auth token provider was unregistered")
+    }
+
+    private static func failAllPendingAuthTokenRequests(reason: String) {
+        authTokenLock.lock()
+        let pending = pendingAuthTokenRequests
+        pendingAuthTokenRequests.removeAll()
+        authTokenLock.unlock()
+        for (_, continuation) in pending {
+            continuation.resume(throwing: authTokenError(reason))
+        }
+    }
+
+    private static func authTokenError(_ message: String) -> NSError {
+        NSError(
+            domain: "KlaviyoReactNativeSdk",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
     }
 
     /// Resolves a pending auth token request. Called from JS once the host
@@ -208,11 +232,7 @@ public class KlaviyoBridge: NSObject {
                     userInfo: [NSLocalizedDescriptionKey: message]
                 ))
             } else {
-                continuation.resume(throwing: NSError(
-                    domain: "KlaviyoReactNativeSdk",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: message]
-                ))
+                continuation.resume(throwing: authTokenError(message))
             }
         }
     }

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -181,7 +181,10 @@ RCT_EXPORT_METHOD(unregisterAuthTokenProvider) {
 RCT_EXPORT_METHOD(respondToAuthTokenRequest: (NSString *)identifier response:(NSDictionary *)response) {
     NSString *jwt = [response[@"jwt"] isKindOfClass:[NSString class]] ? response[@"jwt"] : nil;
     NSString *error = [response[@"error"] isKindOfClass:[NSString class]] ? response[@"error"] : nil;
-    [KlaviyoBridge respondToAuthTokenRequestWithId:identifier jwt:jwt error:error];
+    BOOL isConnectivityError = [response[@"isConnectivityError"] isKindOfClass:[NSNumber class]]
+        ? [response[@"isConnectivityError"] boolValue]
+        : NO;
+    [KlaviyoBridge respondToAuthTokenRequestWithId:identifier jwt:jwt error:error isConnectivityError:isConnectivityError];
 }
 
 @end

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE()
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"FormLifecycleEvent"];
+    return @[@"FormLifecycleEvent", @"klaviyo:authTokenRequested"];
 }
 
 // The values here eventually should come from the iOS SDK once exposed there.
@@ -162,6 +162,26 @@ RCT_EXPORT_METHOD(unregisterFormLifecycleHandler) {
     dispatch_async(dispatch_get_main_queue(), ^{
         [KlaviyoBridge unregisterFormLifecycleHandler];
     });
+}
+
+RCT_EXPORT_METHOD(registerAuthTokenProvider) {
+    __weak __typeof__(self) weakSelf = self;
+    [KlaviyoBridge registerAuthTokenProviderWithEmit:^(NSDictionary *body) {
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf) {
+            [strongSelf sendEventWithName:@"klaviyo:authTokenRequested" body:body];
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(unregisterAuthTokenProvider) {
+    [KlaviyoBridge unregisterAuthTokenProvider];
+}
+
+RCT_EXPORT_METHOD(respondToAuthTokenRequest: (NSString *)identifier response:(NSDictionary *)response) {
+    NSString *jwt = [response[@"jwt"] isKindOfClass:[NSString class]] ? response[@"jwt"] : nil;
+    NSString *error = [response[@"error"] isKindOfClass:[NSString class]] ? response[@"error"] : nil;
+    [KlaviyoBridge respondToAuthTokenRequestWithId:identifier jwt:jwt error:error];
 }
 
 @end

--- a/ios/KlaviyoReactNativeSdk.mm
+++ b/ios/KlaviyoReactNativeSdk.mm
@@ -166,11 +166,15 @@ RCT_EXPORT_METHOD(unregisterFormLifecycleHandler) {
 
 RCT_EXPORT_METHOD(registerAuthTokenProvider) {
     __weak __typeof__(self) weakSelf = self;
-    [KlaviyoBridge registerAuthTokenProviderWithEmit:^(NSDictionary *body) {
+    [KlaviyoBridge registerAuthTokenProviderWithEmit:^BOOL(NSDictionary *body) {
         __strong __typeof__(weakSelf) strongSelf = weakSelf;
-        if (strongSelf) {
-            [strongSelf sendEventWithName:@"klaviyo:authTokenRequested" body:body];
+        if (strongSelf == nil) {
+            // Module deallocated — the event can't be delivered to JS, so
+            // report failure to emit and let the bridge fail the request fast.
+            return NO;
         }
+        [strongSelf sendEventWithName:@"klaviyo:authTokenRequested" body:body];
+        return YES;
     }];
 }
 

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift" ##, "5.3.1"
+  s.dependency "KlaviyoSwift", "5.3.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation" ##, "5.3.1"
+    s.dependency "KlaviyoLocation", "5.3.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms" ##, "5.3.1"
+    s.dependency "KlaviyoForms", "5.3.1"
   end
 
   s.default_subspecs = :none

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.3.1"
+  s.dependency "KlaviyoSwift" ##, "5.3.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.3.1"
+    s.dependency "KlaviyoLocation" ##, "5.3.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.3.1"
+    s.dependency "KlaviyoForms" ##, "5.3.1"
   end
 
   s.default_subspecs = :none

--- a/src/AuthToken.ts
+++ b/src/AuthToken.ts
@@ -1,0 +1,98 @@
+/**
+ * Interface for the Klaviyo Auth Token API.
+ *
+ * Personalized In-App Forms require the SDK to present a user-identifying JWT to
+ * the Klaviyo backend. The React Native SDK is a thin wrapper: the underlying
+ * native iOS and Android SDKs own all token state management (caching, proactive
+ * refresh, timeouts, WebView injection, and all token-related logging). The
+ * wrapper's sole responsibility is to bridge the host's JS-side provider to the
+ * native SDK.
+ */
+export interface KlaviyoAuthTokenApi {
+  /**
+   * Registers a provider that the native SDK invokes when it needs to acquire or
+   * refresh an authentication token (JWT) for the current end-user.
+   *
+   * The provider is an `async` function returning the current end-user's JWT, by
+   * whatever mechanism the host application uses to obtain one (e.g. calling its
+   * auth server, exchanging an OAuth refresh token, reading from a session
+   * cache). It should read the current user fresh on each invocation rather than
+   * capturing identity at registration.
+   *
+   * Calling this replaces any previously-registered provider. The call itself is
+   * synchronous (fire-and-forget) and returns `void`, consistent with other
+   * configuration methods such as {@link KlaviyoProfileApi.setProfile} and
+   * {@link KlaviyoFormsApi.registerForInAppForms}.
+   *
+   * @param provider Async function that resolves with the current end-user's JWT.
+   */
+  registerAuthTokenProvider(provider: AuthTokenProvider): void;
+
+  /**
+   * Detaches a previously-registered auth token provider — e.g. on user logout.
+   *
+   * Forwards to the native SDK, which clears the provider reference and tears
+   * down all associated token state (cached token, scheduled refresh, in-flight
+   * fetch). Re-registering after unregister works normally.
+   */
+  unregisterAuthTokenProvider(): void;
+}
+
+/**
+ * Host-provided function that supplies an auth token (JWT) to the SDK.
+ *
+ * Invoked by the native SDK when it needs a token. Returns a `Promise` that
+ * resolves with the current end-user's JWT, or rejects if a token cannot be
+ * obtained.
+ */
+export type AuthTokenProvider = () => Promise<string>;
+
+/**
+ * Name of the native-to-JS event emitted over `NativeEventEmitter` when the
+ * native SDK requests an auth token from the wrapper-provided provider.
+ */
+export const AUTH_TOKEN_REQUESTED_EVENT = 'klaviyo:authTokenRequested';
+
+/**
+ * Payload of an {@link AUTH_TOKEN_REQUESTED_EVENT} event.
+ *
+ * The `id` correlation identifier is generated on the native side and must be
+ * echoed back via `respondToAuthTokenRequest` so the native SDK can resolve the
+ * awaiting provider invocation.
+ */
+export interface AuthTokenRequestedEvent {
+  /** Correlation ID identifying this token request. */
+  id: string;
+}
+
+/**
+ * Validates that a value is a non-empty string.
+ */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Parses a raw native event payload into a validated {@link AuthTokenRequestedEvent}.
+ *
+ * Returns `null` and logs a warning if the required `id` correlation field is
+ * missing or empty. Never logs token contents (the request payload carries only
+ * the correlation ID, not a token).
+ *
+ * @param data Raw event data from the native bridge
+ * @returns A validated AuthTokenRequestedEvent, or null if the payload is invalid
+ */
+export function parseAuthTokenRequestedEvent(
+  data: Record<string, unknown>
+): AuthTokenRequestedEvent | null {
+  const { id } = data;
+
+  if (!isNonEmptyString(id)) {
+    console.warn(
+      `[Klaviyo] Ignoring auth token request with invalid id: ${JSON.stringify(id)}`
+    );
+    return null;
+  }
+
+  return { id };
+}

--- a/src/AuthToken.ts
+++ b/src/AuthToken.ts
@@ -32,8 +32,10 @@ export interface KlaviyoAuthTokenApi {
    * Detaches a previously-registered auth token provider — e.g. on user logout.
    *
    * Forwards to the native SDK, which clears the provider reference and tears
-   * down all associated token state (cached token, scheduled refresh, in-flight
-   * fetch). Re-registering after unregister works normally.
+   * down its own token state (cached token, scheduled refresh, and the native
+   * side of any in-flight fetch). A host `provider()` call that is already
+   * running is not aborted — it runs to completion and its late response is
+   * ignored. Re-registering after unregister works normally.
    */
   unregisterAuthTokenProvider(): void;
 }
@@ -129,36 +131,40 @@ export interface ClassifiedProviderError {
  * Classifies a rejected {@link AuthTokenProvider} into a message plus a
  * connectivity flag for the native bridge.
  *
- * A rejection is classified as a connectivity error when either:
- *  - it carries an explicit `isConnectivityError === true` marker (host opt-in,
- *    HTTP-client-agnostic), or
- *  - it matches a well-known React Native network-failure signature: `fetch`
- *    throwing `TypeError: Network request failed`, or an `AbortError`.
+ * Classification order:
+ *  - An explicit boolean `isConnectivityError` marker on the error is
+ *    authoritative in both directions — `true` forces connectivity, `false`
+ *    opts out — regardless of the heuristics below (HTTP-client-agnostic).
+ *  - Otherwise, well-known React Native network-failure signatures are
+ *    auto-detected: an `AbortError`, or `fetch` throwing
+ *    `TypeError: Network request failed`.
+ *  - Everything else is a non-connectivity failure.
  *
- * Everything else is a non-connectivity failure. Token contents are never part
- * of a rejection and are never logged.
+ * Token contents are never part of a rejection and are never logged.
  */
 export function classifyProviderError(error: unknown): ClassifiedProviderError {
   const message = error instanceof Error ? error.message : String(error);
 
-  let isConnectivityError = false;
-
+  // An explicit boolean marker wins over the auto-detect heuristics.
   if (typeof error === 'object' && error !== null) {
-    const err = error as { isConnectivityError?: unknown; name?: unknown };
-    if (err.isConnectivityError === true || err.name === 'AbortError') {
-      isConnectivityError = true;
+    const marker = (error as { isConnectivityError?: unknown })
+      .isConnectivityError;
+    if (typeof marker === 'boolean') {
+      return { message, isConnectivityError: marker };
     }
   }
 
+  const isAbortError =
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: unknown }).name === 'AbortError';
   // React Native's `fetch` throws `TypeError: Network request failed` when the
   // request cannot reach the network.
-  if (
-    !isConnectivityError &&
-    error instanceof TypeError &&
-    /network request failed/i.test(message)
-  ) {
-    isConnectivityError = true;
-  }
+  const isFetchNetworkFailure =
+    error instanceof TypeError && /network request failed/i.test(message);
 
-  return { message, isConnectivityError };
+  return {
+    message,
+    isConnectivityError: isAbortError || isFetchNetworkFailure,
+  };
 }

--- a/src/AuthToken.ts
+++ b/src/AuthToken.ts
@@ -1,3 +1,5 @@
+import { isNonEmptyString } from './validation';
+
 /**
  * Interface for the Klaviyo Auth Token API.
  *
@@ -79,13 +81,6 @@ export const AUTH_TOKEN_REQUESTED_EVENT = 'klaviyo:authTokenRequested';
 export interface AuthTokenRequestedEvent {
   /** Correlation ID identifying this token request. */
   id: string;
-}
-
-/**
- * Validates that a value is a non-empty string.
- */
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
 }
 
 /**

--- a/src/AuthToken.ts
+++ b/src/AuthToken.ts
@@ -44,6 +44,20 @@ export interface KlaviyoAuthTokenApi {
  * Invoked by the native SDK when it needs a token. Returns a `Promise` that
  * resolves with the current end-user's JWT, or rejects if a token cannot be
  * obtained.
+ *
+ * **Connectivity failures:** if the provider rejects because the device is
+ * offline, the SDK can wait for connectivity to return and retry — but only
+ * when it can recognize the failure as a network error. The bridge auto-detects
+ * React Native's `fetch` network failure (`TypeError: Network request failed`)
+ * and `AbortError`. If the host uses a different HTTP client, it can opt in
+ * explicitly by rejecting with an error carrying `isConnectivityError === true`:
+ *
+ * ```ts
+ * throw Object.assign(new Error('offline'), { isConnectivityError: true });
+ * ```
+ *
+ * All other rejections are treated as non-connectivity failures (no
+ * connectivity-driven retry), matching the native SDKs' error classification.
  */
 export type AuthTokenProvider = () => Promise<string>;
 
@@ -95,4 +109,56 @@ export function parseAuthTokenRequestedEvent(
   }
 
   return { id };
+}
+
+/**
+ * Result of classifying a provider rejection before it is sent back to native.
+ */
+export interface ClassifiedProviderError {
+  /** Human-readable failure message (never a token). */
+  message: string;
+  /**
+   * Whether the failure is a connectivity error. When `true`, the native bridge
+   * reconstitutes a typed network error (`URLError` on iOS, `IOException` on
+   * Android) that the SDK's connectivity-driven refresh retry recognizes.
+   */
+  isConnectivityError: boolean;
+}
+
+/**
+ * Classifies a rejected {@link AuthTokenProvider} into a message plus a
+ * connectivity flag for the native bridge.
+ *
+ * A rejection is classified as a connectivity error when either:
+ *  - it carries an explicit `isConnectivityError === true` marker (host opt-in,
+ *    HTTP-client-agnostic), or
+ *  - it matches a well-known React Native network-failure signature: `fetch`
+ *    throwing `TypeError: Network request failed`, or an `AbortError`.
+ *
+ * Everything else is a non-connectivity failure. Token contents are never part
+ * of a rejection and are never logged.
+ */
+export function classifyProviderError(error: unknown): ClassifiedProviderError {
+  const message = error instanceof Error ? error.message : String(error);
+
+  let isConnectivityError = false;
+
+  if (typeof error === 'object' && error !== null) {
+    const err = error as { isConnectivityError?: unknown; name?: unknown };
+    if (err.isConnectivityError === true || err.name === 'AbortError') {
+      isConnectivityError = true;
+    }
+  }
+
+  // React Native's `fetch` throws `TypeError: Network request failed` when the
+  // request cannot reach the network.
+  if (
+    !isConnectivityError &&
+    error instanceof TypeError &&
+    /network request failed/i.test(message)
+  ) {
+    isConnectivityError = true;
+  }
+
+  return { message, isConnectivityError };
 }

--- a/src/AuthToken.ts
+++ b/src/AuthToken.ts
@@ -143,7 +143,12 @@ export interface ClassifiedProviderError {
  * Token contents are never part of a rejection and are never logged.
  */
 export function classifyProviderError(error: unknown): ClassifiedProviderError {
-  const message = error instanceof Error ? error.message : String(error);
+  // Raw host text is used ONLY for internal connectivity auto-detection below;
+  // it is never returned/logged/forwarded (it could contain the JWT).
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  // The reported message is redacted to the error's type — safe to log and
+  // forward to native, and still useful for diagnosis.
+  const message = redactErrorType(error);
 
   // An explicit boolean marker wins over the auto-detect heuristics.
   if (typeof error === 'object' && error !== null) {
@@ -161,10 +166,23 @@ export function classifyProviderError(error: unknown): ClassifiedProviderError {
   // React Native's `fetch` throws `TypeError: Network request failed` when the
   // request cannot reach the network.
   const isFetchNetworkFailure =
-    error instanceof TypeError && /network request failed/i.test(message);
+    error instanceof TypeError && /network request failed/i.test(rawMessage);
 
   return {
     message,
     isConnectivityError: isAbortError || isFetchNetworkFailure,
   };
+}
+
+/**
+ * Returns a safe, non-sensitive descriptor of an error: its runtime type name
+ * (e.g. `Error`, `TypeError`, or a custom class name), or `typeof` for
+ * non-object rejections. Never returns host-controlled text such as
+ * `error.message`, which could contain the JWT or other credentials.
+ */
+function redactErrorType(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    return error.constructor?.name ?? 'Object';
+  }
+  return typeof error;
 }

--- a/src/Forms.ts
+++ b/src/Forms.ts
@@ -1,3 +1,5 @@
+import { isNonEmptyString } from './validation';
+
 /**
  * Interface for the Klaviyo Forms API
  */
@@ -122,13 +124,6 @@ export type FormLifecycleHandler = (event: FormLifecycleEvent) => void;
 
 const FORM_LIFECYCLE_EVENT_TYPES: readonly FormLifecycleEventType[] =
   Object.values(FormLifecycleEventType);
-
-/**
- * Validates that a value is a non-empty string.
- */
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
-}
 
 /**
  * Parses a raw native event payload into a validated {@link FormLifecycleEvent}.

--- a/src/Klaviyo.ts
+++ b/src/Klaviyo.ts
@@ -4,6 +4,7 @@ import type { KlaviyoPushApi } from './Push';
 import type { KlaviyoFormsApi } from './Forms';
 import type { KlaviyoGeofencingApi } from './Geofencing';
 import type { KlaviyoDeepLinkAPI } from './KlaviyoDeepLinkAPI';
+import type { KlaviyoAuthTokenApi } from './AuthToken';
 
 /**
  * The Klaviyo React Native SDK Interface
@@ -18,7 +19,8 @@ export interface KlaviyoInterface
     KlaviyoPushApi,
     KlaviyoGeofencingApi,
     KlaviyoFormsApi,
-    KlaviyoDeepLinkAPI {
+    KlaviyoDeepLinkAPI,
+    KlaviyoAuthTokenApi {
   /**
    * Initializes the Klaviyo SDK with the given API key.
    *

--- a/src/__tests__/AuthToken.test.ts
+++ b/src/__tests__/AuthToken.test.ts
@@ -127,6 +127,16 @@ describe('classifyProviderError', () => {
     expect(classifyProviderError(error).isConnectivityError).toBe(false);
   });
 
+  it('lets an explicit false marker opt out of auto-detection', () => {
+    // A fetch-style network failure that the host explicitly marks as
+    // non-connectivity must be honored (explicit boolean wins).
+    const error = Object.assign(new TypeError('Network request failed'), {
+      isConnectivityError: false,
+    });
+
+    expect(classifyProviderError(error).isConnectivityError).toBe(false);
+  });
+
   it('does not classify an unrelated error as connectivity', () => {
     expect(
       classifyProviderError(new Error('HTTP 500')).isConnectivityError

--- a/src/__tests__/AuthToken.test.ts
+++ b/src/__tests__/AuthToken.test.ts
@@ -1,0 +1,70 @@
+import { parseAuthTokenRequestedEvent } from '../AuthToken';
+
+describe('parseAuthTokenRequestedEvent', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('valid events', () => {
+    it('parses an event with a non-empty id', () => {
+      const result = parseAuthTokenRequestedEvent({ id: 'req-123' });
+
+      expect(result).toEqual({ id: 'req-123' });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('ignores extra fields and returns only the id', () => {
+      const result = parseAuthTokenRequestedEvent({
+        id: 'req-123',
+        unexpected: 'field',
+      });
+
+      expect(result).toEqual({ id: 'req-123' });
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('invalid events', () => {
+    it('returns null and warns when id is missing', () => {
+      const result = parseAuthTokenRequestedEvent({});
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+    });
+
+    it('returns null when id is an empty string', () => {
+      const result = parseAuthTokenRequestedEvent({ id: '' });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+    });
+
+    it('returns null when id is not a string', () => {
+      const result = parseAuthTokenRequestedEvent({ id: 42 });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+    });
+
+    it('returns null when id is null', () => {
+      const result = parseAuthTokenRequestedEvent({ id: null });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+    });
+  });
+});

--- a/src/__tests__/AuthToken.test.ts
+++ b/src/__tests__/AuthToken.test.ts
@@ -52,6 +52,15 @@ describe('parseAuthTokenRequestedEvent', () => {
       );
     });
 
+    it('returns null when id is whitespace-only', () => {
+      const result = parseAuthTokenRequestedEvent({ id: '   ' });
+
+      expect(result).toBeNull();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+    });
+
     it('returns null when id is not a string', () => {
       const result = parseAuthTokenRequestedEvent({ id: 42 });
 

--- a/src/__tests__/AuthToken.test.ts
+++ b/src/__tests__/AuthToken.test.ts
@@ -1,4 +1,7 @@
-import { parseAuthTokenRequestedEvent } from '../AuthToken';
+import {
+  classifyProviderError,
+  parseAuthTokenRequestedEvent,
+} from '../AuthToken';
 
 describe('parseAuthTokenRequestedEvent', () => {
   let consoleWarnSpy: jest.SpyInstance;
@@ -66,5 +69,67 @@ describe('parseAuthTokenRequestedEvent', () => {
         expect.stringContaining('invalid id')
       );
     });
+  });
+});
+
+describe('classifyProviderError', () => {
+  it('extracts the message from an Error', () => {
+    expect(classifyProviderError(new Error('boom'))).toEqual({
+      message: 'boom',
+      isConnectivityError: false,
+    });
+  });
+
+  it('stringifies a non-Error rejection', () => {
+    expect(classifyProviderError('plain string')).toEqual({
+      message: 'plain string',
+      isConnectivityError: false,
+    });
+  });
+
+  it('honors an explicit isConnectivityError marker', () => {
+    const error = Object.assign(new Error('offline'), {
+      isConnectivityError: true,
+    });
+
+    expect(classifyProviderError(error)).toEqual({
+      message: 'offline',
+      isConnectivityError: true,
+    });
+  });
+
+  it('does not classify when the marker is not exactly true', () => {
+    const error = Object.assign(new Error('nope'), {
+      isConnectivityError: 'yes',
+    });
+
+    expect(classifyProviderError(error).isConnectivityError).toBe(false);
+  });
+
+  it("auto-detects React Native's fetch network failure", () => {
+    const error = new TypeError('Network request failed');
+
+    expect(classifyProviderError(error)).toEqual({
+      message: 'Network request failed',
+      isConnectivityError: true,
+    });
+  });
+
+  it('auto-detects an AbortError', () => {
+    const error = Object.assign(new Error('aborted'), { name: 'AbortError' });
+
+    expect(classifyProviderError(error).isConnectivityError).toBe(true);
+  });
+
+  it('does not classify a generic TypeError as connectivity', () => {
+    const error = new TypeError('x is not a function');
+
+    expect(classifyProviderError(error).isConnectivityError).toBe(false);
+  });
+
+  it('does not classify an unrelated error as connectivity', () => {
+    expect(
+      classifyProviderError(new Error('HTTP 500')).isConnectivityError
+    ).toBe(false);
   });
 });

--- a/src/__tests__/AuthToken.test.ts
+++ b/src/__tests__/AuthToken.test.ts
@@ -73,16 +73,29 @@ describe('parseAuthTokenRequestedEvent', () => {
 });
 
 describe('classifyProviderError', () => {
-  it('extracts the message from an Error', () => {
+  it('reports the error type, not host-controlled text', () => {
+    // The message must be redacted to the error's type — never error.message,
+    // which could contain the JWT.
     expect(classifyProviderError(new Error('boom'))).toEqual({
-      message: 'boom',
+      message: 'Error',
       isConnectivityError: false,
     });
   });
 
-  it('stringifies a non-Error rejection', () => {
+  it('never surfaces host-controlled exception text', () => {
+    const error = new Error(
+      'failed with token=eyJhbGciOiJIUzI1NiJ9.secret.sig'
+    );
+
+    const { message } = classifyProviderError(error);
+    expect(message).not.toContain('secret');
+    expect(message).not.toContain('eyJ');
+    expect(message).toBe('Error');
+  });
+
+  it('reports the typeof for a non-Error rejection', () => {
     expect(classifyProviderError('plain string')).toEqual({
-      message: 'plain string',
+      message: 'string',
       isConnectivityError: false,
     });
   });
@@ -93,7 +106,7 @@ describe('classifyProviderError', () => {
     });
 
     expect(classifyProviderError(error)).toEqual({
-      message: 'offline',
+      message: 'Error',
       isConnectivityError: true,
     });
   });
@@ -109,8 +122,10 @@ describe('classifyProviderError', () => {
   it("auto-detects React Native's fetch network failure", () => {
     const error = new TypeError('Network request failed');
 
+    // Message is redacted to the type, but connectivity detection still keys
+    // off the raw text internally, so the flag must remain true.
     expect(classifyProviderError(error)).toEqual({
-      message: 'Network request failed',
+      message: 'TypeError',
       isConnectivityError: true,
     });
   });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -866,6 +866,24 @@ describe('Klaviyo SDK', () => {
       ).toHaveBeenCalledWith('req-1', { jwt: 'jwt-abc' });
     });
 
+    it('routes an empty-string resolution through the failure path', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const provider = jest.fn().mockResolvedValue('');
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-empty' });
+      await flushPromises();
+
+      const call = (
+        NativeModules.KlaviyoReactNativeSdk
+          .respondToAuthTokenRequest as jest.Mock
+      ).mock.calls[0];
+      expect(call[0]).toBe('req-empty');
+      expect(call[1]).not.toHaveProperty('jwt');
+      expect(call[1].error).toEqual(expect.stringContaining('without a token'));
+      consoleErrorSpy.mockRestore();
+    });
+
     it('responds with an error message when the provider rejects', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       const provider = jest

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -984,7 +984,14 @@ describe('Klaviyo SDK', () => {
     it('unregisters the native provider and removes the listener', () => {
       const provider = jest.fn().mockResolvedValue('jwt');
       Klaviyo.registerAuthTokenProvider(provider);
+      // Clear counts from registration (which may tear down a leftover
+      // subscription from a prior test) so we assert only the explicit
+      // unregister call below.
       mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterAuthTokenProvider as jest.Mock
+      ).mockClear();
 
       Klaviyo.unregisterAuthTokenProvider();
 
@@ -1011,11 +1018,19 @@ describe('Klaviyo SDK', () => {
 
       Klaviyo.registerAuthTokenProvider(provider1);
       mockRemove.mockClear();
+      (
+        NativeModules.KlaviyoReactNativeSdk
+          .unregisterAuthTokenProvider as jest.Mock
+      ).mockClear();
 
       Klaviyo.registerAuthTokenProvider(provider2);
 
-      // The previous subscription is torn down before the new one is added.
+      // The previous subscription is torn down before the new one is added,
+      // and the native side is unregistered so pending requests are drained.
       expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterAuthTokenProvider
+      ).toHaveBeenCalledTimes(1);
     });
 
     it('routes a request to only the most recently registered provider', async () => {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -30,6 +30,9 @@ jest.mock('react-native', () => {
         unregisterFromInAppForms: jest.fn(),
         registerFormLifecycleHandler: jest.fn(),
         unregisterFormLifecycleHandler: jest.fn(),
+        registerAuthTokenProvider: jest.fn(),
+        unregisterAuthTokenProvider: jest.fn(),
+        respondToAuthTokenRequest: jest.fn(),
         registerGeofencing: jest.fn(),
         unregisterGeofencing: jest.fn(),
         getCurrentGeofences: jest.fn(),
@@ -833,6 +836,139 @@ describe('Klaviyo SDK', () => {
         expect.stringContaining('missing required field(s): deepLinkUrl')
       );
       consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('auth token provider', () => {
+    // The event listener is async (awaits the host provider), so tests must
+    // flush the microtask queue after emitting before asserting on the
+    // resulting `respondToAuthTokenRequest` call.
+    const flushPromises = () => new Promise(process.nextTick);
+
+    it('registers the native provider and subscribes to the request event', () => {
+      Klaviyo.registerAuthTokenProvider(() => Promise.resolve('jwt-123'));
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.registerAuthTokenProvider
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes the provider and responds with the jwt on success', async () => {
+      const provider = jest.fn().mockResolvedValue('jwt-abc');
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-1' });
+      await flushPromises();
+
+      expect(provider).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).toHaveBeenCalledWith('req-1', { jwt: 'jwt-abc' });
+    });
+
+    it('responds with an error message when the provider rejects', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const provider = jest
+        .fn()
+        .mockRejectedValue(new Error('auth server down'));
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-2' });
+      await flushPromises();
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).toHaveBeenCalledWith('req-2', { error: 'auth server down' });
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not log the token contents on success', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      Klaviyo.registerAuthTokenProvider(() => Promise.resolve('secret-jwt'));
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-3' });
+      await flushPromises();
+
+      for (const spy of [consoleWarnSpy, consoleErrorSpy, consoleLogSpy]) {
+        for (const call of spy.mock.calls) {
+          expect(call.join(' ')).not.toContain('secret-jwt');
+        }
+      }
+      consoleWarnSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+    });
+
+    it('ignores requests with a missing or empty id', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const provider = jest.fn().mockResolvedValue('jwt');
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', {});
+      emitNativeEvent('klaviyo:authTokenRequested', { id: '' });
+      await flushPromises();
+
+      expect(provider).not.toHaveBeenCalled();
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('invalid id')
+      );
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('unregisters the native provider and removes the listener', () => {
+      const provider = jest.fn().mockResolvedValue('jwt');
+      Klaviyo.registerAuthTokenProvider(provider);
+      mockRemove.mockClear();
+
+      Klaviyo.unregisterAuthTokenProvider();
+
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.unregisterAuthTokenProvider
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops forwarding requests after unregistering', async () => {
+      const provider = jest.fn().mockResolvedValue('jwt');
+      Klaviyo.registerAuthTokenProvider(provider);
+      Klaviyo.unregisterAuthTokenProvider();
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-4' });
+      await flushPromises();
+
+      expect(provider).not.toHaveBeenCalled();
+    });
+
+    it('replaces the previous listener when re-registering', () => {
+      const provider1 = jest.fn().mockResolvedValue('jwt-1');
+      const provider2 = jest.fn().mockResolvedValue('jwt-2');
+
+      Klaviyo.registerAuthTokenProvider(provider1);
+      mockRemove.mockClear();
+
+      Klaviyo.registerAuthTokenProvider(provider2);
+
+      // The previous subscription is torn down before the new one is added.
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a request to only the most recently registered provider', async () => {
+      const provider1 = jest.fn().mockResolvedValue('jwt-1');
+      const provider2 = jest.fn().mockResolvedValue('jwt-2');
+
+      Klaviyo.registerAuthTokenProvider(provider1);
+      Klaviyo.registerAuthTokenProvider(provider2);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-5' });
+      await flushPromises();
+
+      expect(provider1).not.toHaveBeenCalled();
+      expect(provider2).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -880,15 +880,20 @@ describe('Klaviyo SDK', () => {
       ).mock.calls[0];
       expect(call[0]).toBe('req-empty');
       expect(call[1]).not.toHaveProperty('jwt');
-      expect(call[1].error).toEqual(expect.stringContaining('without a token'));
+      // The empty resolution is routed through the failure path; the forwarded
+      // error is the redacted type (the thrown Error), not raw text.
+      expect(call[1].error).toBe('Error');
+      expect(call[1].isConnectivityError).toBe(false);
       consoleErrorSpy.mockRestore();
     });
 
-    it('responds with an error message when the provider rejects', async () => {
+    it('responds with a redacted error type when the provider rejects', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      // Host error text (which could contain the JWT) must not be forwarded —
+      // only the error type is sent to native.
       const provider = jest
         .fn()
-        .mockRejectedValue(new Error('auth server down'));
+        .mockRejectedValue(new Error('auth server down token=secret'));
       Klaviyo.registerAuthTokenProvider(provider);
 
       emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-2' });
@@ -897,7 +902,7 @@ describe('Klaviyo SDK', () => {
       expect(
         NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
       ).toHaveBeenCalledWith('req-2', {
-        error: 'auth server down',
+        error: 'Error',
         isConnectivityError: false,
       });
       consoleErrorSpy.mockRestore();
@@ -916,7 +921,7 @@ describe('Klaviyo SDK', () => {
       expect(
         NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
       ).toHaveBeenCalledWith('req-net', {
-        error: 'Network request failed',
+        error: 'TypeError',
         isConnectivityError: true,
       });
       consoleErrorSpy.mockRestore();
@@ -937,7 +942,7 @@ describe('Klaviyo SDK', () => {
       expect(
         NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
       ).toHaveBeenCalledWith('req-marker', {
-        error: 'offline',
+        error: 'Error',
         isConnectivityError: true,
       });
       consoleErrorSpy.mockRestore();
@@ -1010,6 +1015,30 @@ describe('Klaviyo SDK', () => {
       await flushPromises();
 
       expect(provider).not.toHaveBeenCalled();
+    });
+
+    it('drops a token fetched after the provider is unregistered mid-flight', async () => {
+      // A slow provider that resolves after the user has logged out
+      // (unregister) must not hand the now-stale token to native.
+      let resolveProvider!: (value: string) => void;
+      const provider = jest.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveProvider = resolve;
+          })
+      );
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-inflight' });
+      // provider() is now in flight; log out before it resolves.
+      Klaviyo.unregisterAuthTokenProvider();
+      resolveProvider('jwt-after-logout');
+      await flushPromises();
+
+      expect(provider).toHaveBeenCalledTimes(1);
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).not.toHaveBeenCalled();
     });
 
     it('replaces the previous listener when re-registering', () => {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -878,7 +878,50 @@ describe('Klaviyo SDK', () => {
 
       expect(
         NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
-      ).toHaveBeenCalledWith('req-2', { error: 'auth server down' });
+      ).toHaveBeenCalledWith('req-2', {
+        error: 'auth server down',
+        isConnectivityError: false,
+      });
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('flags connectivity errors so native can arm retry', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const provider = jest
+        .fn()
+        .mockRejectedValue(new TypeError('Network request failed'));
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-net' });
+      await flushPromises();
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).toHaveBeenCalledWith('req-net', {
+        error: 'Network request failed',
+        isConnectivityError: true,
+      });
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('honors an explicit isConnectivityError marker on the rejection', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const provider = jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('offline'), { isConnectivityError: true })
+        );
+      Klaviyo.registerAuthTokenProvider(provider);
+
+      emitNativeEvent('klaviyo:authTokenRequested', { id: 'req-marker' });
+      await flushPromises();
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.respondToAuthTokenRequest
+      ).toHaveBeenCalledWith('req-marker', {
+        error: 'offline',
+        isConnectivityError: true,
+      });
       consoleErrorSpy.mockRestore();
     });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,9 +184,13 @@ export const Klaviyo: KlaviyoInterface = {
   },
   registerAuthTokenProvider(provider: AuthTokenProvider): void {
     // Clean up any existing subscription before re-registering so the new
-    // provider replaces the previous one (matches native SDK semantics).
+    // provider replaces the previous one. Mirror the native teardown done on
+    // re-registration for form lifecycle handlers: also unregister on the
+    // native side so pending token requests are drained and a prior provider's
+    // in-flight handler can't resolve a stale request.
     if (activeAuthTokenSubscription) {
       activeAuthTokenSubscription.remove();
+      KlaviyoReactNativeSdk.unregisterAuthTokenProvider();
       activeAuthTokenSubscription = null;
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,11 @@ import type { Event } from './Event';
 import type { FormConfiguration, FormLifecycleHandler } from './Forms';
 import { parseFormLifecycleEvent } from './Forms';
 import type { Geofence } from './Geofencing';
+import type { AuthTokenProvider } from './AuthToken';
+import {
+  AUTH_TOKEN_REQUESTED_EVENT,
+  parseAuthTokenRequestedEvent,
+} from './AuthToken';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 
 const FORMS_UNAVAILABLE_MESSAGE =
@@ -40,6 +45,9 @@ function isLocationAvailable(): boolean {
 
 // Track active lifecycle subscription to prevent duplicate listeners
 let activeLifecycleSubscription: { remove: () => void } | null = null;
+
+// Track active auth token request subscription to prevent duplicate listeners
+let activeAuthTokenSubscription: { remove: () => void } | null = null;
 
 /**
  * Implementation of the {@link KlaviyoInterface}
@@ -173,6 +181,50 @@ export const Klaviyo: KlaviyoInterface = {
       KlaviyoReactNativeSdk.unregisterFormLifecycleHandler();
     };
   },
+  registerAuthTokenProvider(provider: AuthTokenProvider): void {
+    // Clean up any existing subscription before re-registering so the new
+    // provider replaces the previous one (matches native SDK semantics).
+    if (activeAuthTokenSubscription) {
+      activeAuthTokenSubscription.remove();
+      activeAuthTokenSubscription = null;
+    }
+
+    const eventEmitter = new NativeEventEmitter(
+      NativeModules.KlaviyoReactNativeSdk
+    );
+
+    activeAuthTokenSubscription = eventEmitter.addListener(
+      AUTH_TOKEN_REQUESTED_EVENT,
+      async (data: Record<string, unknown>) => {
+        const event = parseAuthTokenRequestedEvent(data);
+        if (event === null) {
+          return;
+        }
+
+        try {
+          const jwt = await provider();
+          // NOTE: never log token contents; native side owns token logging.
+          KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, { jwt });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(
+            `[Klaviyo] Auth token provider failed for request ${event.id}: ${message}`
+          );
+          KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, {
+            error: message,
+          });
+        }
+      }
+    );
+
+    KlaviyoReactNativeSdk.registerAuthTokenProvider();
+  },
+  unregisterAuthTokenProvider(): void {
+    activeAuthTokenSubscription?.remove();
+    activeAuthTokenSubscription = null;
+    KlaviyoReactNativeSdk.unregisterAuthTokenProvider();
+  },
 };
 
 export { type Event, type EventProperties, EventName } from './Event';
@@ -192,3 +244,4 @@ export type {
 } from './Forms';
 export type { KlaviyoDeepLinkAPI } from './KlaviyoDeepLinkAPI';
 export type { Geofence } from './Geofencing';
+export type { AuthTokenProvider, KlaviyoAuthTokenApi } from './AuthToken';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import type { Geofence } from './Geofencing';
 import type { AuthTokenProvider } from './AuthToken';
 import {
   AUTH_TOKEN_REQUESTED_EVENT,
+  classifyProviderError,
   parseAuthTokenRequestedEvent,
 } from './AuthToken';
 import { NativeEventEmitter, NativeModules } from 'react-native';
@@ -206,13 +207,15 @@ export const Klaviyo: KlaviyoInterface = {
           // NOTE: never log token contents; native side owns token logging.
           KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, { jwt });
         } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const { message, isConnectivityError } = classifyProviderError(error);
           console.error(
             `[Klaviyo] Auth token provider failed for request ${event.id}: ${message}`
           );
+          // Forward the connectivity flag so native can reconstitute a typed
+          // network error the SDK's connectivity-driven retry recognizes.
           KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, {
             error: message,
+            isConnectivityError,
           });
         }
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -204,6 +204,11 @@ export const Klaviyo: KlaviyoInterface = {
 
         try {
           const jwt = await provider();
+          if (typeof jwt !== 'string' || jwt.length === 0) {
+            // Route an empty / non-string resolution through the failure path
+            // so native gets a clear signal rather than a bogus "success".
+            throw new Error('Auth token provider resolved without a token');
+          }
           // NOTE: never log token contents; native side owns token logging.
           KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, { jwt });
         } catch (error) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,6 +50,11 @@ let activeLifecycleSubscription: { remove: () => void } | null = null;
 // Track active auth token request subscription to prevent duplicate listeners
 let activeAuthTokenSubscription: { remove: () => void } | null = null;
 
+// The currently-registered provider. Captured so an in-flight provider() call
+// that resolves after unregister/re-register (e.g. logout) can be detected and
+// its now-stale result dropped rather than delivered to native.
+let activeAuthTokenProvider: AuthTokenProvider | null = null;
+
 /**
  * Implementation of the {@link KlaviyoInterface}
  */
@@ -194,6 +199,8 @@ export const Klaviyo: KlaviyoInterface = {
       activeAuthTokenSubscription = null;
     }
 
+    activeAuthTokenProvider = provider;
+
     const eventEmitter = new NativeEventEmitter(
       NativeModules.KlaviyoReactNativeSdk
     );
@@ -208,6 +215,13 @@ export const Klaviyo: KlaviyoInterface = {
 
         try {
           const jwt = await provider();
+          // If the provider was unregistered or replaced while this fetch was
+          // in flight (e.g. logout), drop the result — do not deliver a token
+          // acquired for a now-inactive provider. Native already drained this
+          // request's continuation on unregister, so no response is owed.
+          if (activeAuthTokenProvider !== provider) {
+            return;
+          }
           if (typeof jwt !== 'string' || jwt.length === 0) {
             // Route an empty / non-string resolution through the failure path
             // so native gets a clear signal rather than a bogus "success".
@@ -216,6 +230,11 @@ export const Klaviyo: KlaviyoInterface = {
           // NOTE: never log token contents; native side owns token logging.
           KlaviyoReactNativeSdk.respondToAuthTokenRequest(event.id, { jwt });
         } catch (error) {
+          // Same in-flight guard for the rejection path: a late failure for an
+          // inactive provider is dropped rather than forwarded.
+          if (activeAuthTokenProvider !== provider) {
+            return;
+          }
           const { message, isConnectivityError } = classifyProviderError(error);
           console.error(
             `[Klaviyo] Auth token provider failed for request ${event.id}: ${message}`
@@ -235,6 +254,7 @@ export const Klaviyo: KlaviyoInterface = {
   unregisterAuthTokenProvider(): void {
     activeAuthTokenSubscription?.remove();
     activeAuthTokenSubscription = null;
+    activeAuthTokenProvider = null;
     KlaviyoReactNativeSdk.unregisterAuthTokenProvider();
   },
 };

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -3,8 +3,9 @@
  */
 
 /**
- * Validates that a value is a non-empty string.
+ * Validates that a value is a non-empty string, treating whitespace-only
+ * strings as empty (a blank bridged payload is not a meaningful value).
  */
 export function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
+  return typeof value === 'string' && value.trim().length > 0;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared validation helpers for bridge payloads.
+ */
+
+/**
+ * Validates that a value is a non-empty string.
+ */
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}


### PR DESCRIPTION
# Description

Bridges a JS-side JWT auth-token provider to the native iOS/Android SDKs for personalized In-App Forms. The wrapper does no token state management of its own — it forwards the host's `AuthTokenProvider` to the native SDKs (which own caching, refresh, timeouts, WebView injection, and logging) using a correlation-ID request/response over `NativeEventEmitter`.

> [!IMPORTANT]
> **Draft — do not merge yet.**
> - The auth-token APIs this depends on are only on the native SDKs' `feat/jwts-for-personalized-forms` branches (unreleased). This can't ship until those release and the version pins are bumped.
> - Targets **`feat/jwts-for-personalized-forms`** (not `master`).
> - This PR contains a temporary commit — **`[REVERT] pin native SDKs to feat/jwts branches so CI compiles`** — pinning Android (JitPack, `klaviyo-android-sdk` commit `de5f870343`) and iOS (`:git`/`:branch` pods) to the unreleased native SDKs so native CI compiles green. **It MUST be reverted before merge**, replaced by a bump to the released native versions.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - JS layer covered by unit tests (84 Jest tests pass). Native example apps now **compile green on CI** (iOS + Android, new & old arch) against the feat-branch SDKs. Full manual E2E on a device is still pending — needs a run on a real machine.
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
  - Manual test UI for the example app is tracked separately in MAGE-879.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [ ] `Patch`
- [x] `Minor` Contains changes to the public API (adds `Klaviyo.registerAuthTokenProvider` / `unregisterAuthTokenProvider`).
- [ ] `Major`
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release (JWT support for personalized In-App Forms).

## Changelog / Code Overview

**Public API** (`src/AuthToken.ts`, `src/Klaviyo.ts`, `src/index.tsx`)
- `Klaviyo.registerAuthTokenProvider(provider: () => Promise<string>): void` — fire-and-forget, matches `setProfile` / `registerForInAppForms`.
- `Klaviyo.unregisterAuthTokenProvider(): void` — forwards to the native unregister and tears down the JS listener.

**Bridge flow** (correlation-ID request/response, mirrors the existing `FormLifecycleEvent` pattern)
- Native invokes its wrapper-provided provider → generates a correlation ID → emits `klaviyo:authTokenRequested` `{ id }` over `NativeEventEmitter` → awaits.
- JS listener runs the host provider, then calls `respondToAuthTokenRequest(id, { jwt })` on success or `{ error, isConnectivityError }` on failure.
- Native correlates by ID and resolves the awaiting provider invocation. iOS uses an `NSLock`-guarded `[String: CheckedContinuation]` with `withTaskCancellationHandler` (SDK timeout → cancellation → evict, no leak); Android uses a `ConcurrentHashMap<id, AuthTokenProvider.Callback>`. Both claim-and-remove atomically for exactly-once resolution.

**Connectivity error classification**
- The native SDKs only arm their connectivity-driven refresh retry for typed network errors (`URLError.isConnectivityError` / `IOException`). A JS rejection crosses the bridge as a string, so `classifyProviderError` detects connectivity failures — explicit `error.isConnectivityError` boolean (authoritative both ways), else auto-detect RN's `fetch` `TypeError: Network request failed` / `AbortError` — and the native side reconstitutes `URLError(.notConnectedToInternet)` / `IOException` so the retry fires.

**Logging:** bridge-level diagnostics only via `console.warn` / `console.error`; token contents are never logged (enforced by a test).

## Test Plan

- **Automated (done):** `yarn typecheck`, `yarn lint`, `yarn test` (84 pass — parser, classifier, and bridge round-trip incl. connectivity classification, re-register replacement, teardown), `yarn prepare`.
- **Manual (pending, needs a real machine):** point at the native branches via `./configure-sdk.sh -l`, run `yarn example ios` / `yarn example android`, then exercise register → eager fetch → refresh, success/error/connectivity outcomes, and unregister. Full manual UI to be built in MAGE-879.

## Related Issues/Tickets

- Part of MAGE-610
- Manual test app UI: MAGE-879
- Native dependencies (both Done): MAGE-685 (iOS unregister), MAGE-686 (Android unregister)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auth-token provider API (register/unregister) that fulfills native auth-token requests via a JS event (`klaviyo:authTokenRequested`), returning either `{ jwt }` or an error payload.
* **Bug Fixes**
  * Improved reliability for request handling during provider switches/teardown, including validation of request IDs and safer error reporting with connectivity-aware classification.
* **Tests**
  * Added Jest and React Native end-to-end coverage for the token request/response flow, parsing, and error classification.
* **Chores**
  * Pinned the Android SDK version and updated the example iOS CocoaPods to use the upstream branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->