### PR TITLE
docs(push): document Android default-on token forwarding + per-platform divergence (MAGE-938)

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,44 @@
 
 This guide outlines how developers can migrate from older versions of our SDK to newer ones.
 
+## Migrating to v2.5.0
+
+### Automatic push token forwarding is now the default on Android
+
+As of v2.5.0 (which pins the native Android SDK to 4.5.0), the Klaviyo SDK forwards the Android FCM
+push token to Klaviyo **automatically by default**. This formalizes behavior the bundled
+`KlaviyoPushService` already performed, and is **non-breaking** — the default preserves existing
+behavior.
+
+**iOS is unchanged:** automatic forwarding remains opt-in (off by default), because iOS token
+collection relies on the more invasive app-delegate method swizzling. The flag's semantics are
+identical across platforms (`false` = no automatic collection); only the per-platform default
+differs, for these platform-specific reasons.
+
+**No action is required** to keep current behavior. If you prefer to own the push-token pipeline
+yourself:
+
+- **Android** — disable automatic forwarding by adding this `meta-data` to the `<application>`
+  element of your `AndroidManifest.xml`, then continue calling `Klaviyo.setPushToken(...)` yourself:
+  ```xml
+  <meta-data
+      android:name="com.klaviyo.push.automatic_push_token_forwarding"
+      android:value="false" />
+  ```
+- **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
+  native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
+
+If you already collect and set the token manually on Android, no change is needed — duplicate tokens
+are deduplicated and cause no extra network request. See the
+[README](./README.md#collecting-push-tokens) for full token-collection guidance.
+
+> **Looking ahead:** a future **major** release may enable **both** `automatic_push_open_tracking`
+> and `automatic_push_token_forwarding` by default on all platforms, bringing automatic push
+> integration to parity. If that happens, apps that prefer to manage push integration manually would
+> need to **opt out** of the enabled defaults (as described above for Android), rather than opt in.
+> This is a non-breaking, forward-looking heads-up — nothing changes until that release, and we will
+> document the exact opt-out steps in its migration guide.
+
 ## Migrating to v2.0.0
 
 ### In-App Forms

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -21,11 +21,13 @@ yourself:
 
 - **Android** — disable automatic forwarding by adding this `meta-data` to the `<application>`
   element of your `AndroidManifest.xml`, then continue calling `Klaviyo.setPushToken(...)` yourself:
+
   ```xml
   <meta-data
       android:name="com.klaviyo.push.automatic_push_token_forwarding"
       android:value="false" />
   ```
+
 - **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
   native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,42 @@ Push tokens can be collected either from your app's react native code or in the 
 Below sections discuss both approaches, and you are free to pick one that best suits your app's architecture.
 Note that doing this in one location is sufficient.
 
+#### Automatic Token Forwarding (Platform Defaults)
+
+Before choosing an approach, note that the underlying native SDKs handle automatic push-token
+forwarding differently by default:
+
+- **Android — on by default.** The native Android SDK auto-registers its `KlaviyoPushService`
+  (a `FirebaseMessagingService`) via manifest merge, so it forwards the FCM token to Klaviyo
+  automatically, without any React Native code. You do not need to collect the token yourself on
+  Android — though doing so is harmless (duplicate tokens are deduplicated and cause no extra
+  network request).
+- **iOS — opt-in (off by default).** iOS token forwarding relies on app-delegate method swizzling,
+  which is more invasive, so the native iOS SDK does not enable it implicitly. By default you set the
+  APNs token manually, as shown below. Automatic forwarding on iOS is opt-in via `Info.plist` — see
+  the native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications).
+
+The flag's semantics are identical on both platforms (`false` = no automatic collection); only the
+default differs, for these platform-specific reasons. Manual token collection (documented below)
+remains the recommended baseline and works on both platforms — automatic forwarding is additive, not
+a replacement.
+
+To **opt out** of automatic forwarding on Android, add the following `meta-data` to the
+`<application>` element of your app's `AndroidManifest.xml` (which your app owns), then register the
+token yourself via `Klaviyo.setPushToken(...)`:
+
+```xml
+<meta-data
+    android:name="com.klaviyo.push.automatic_push_token_forwarding"
+    android:value="false" />
+```
+
+This is the single, complete opt-out — with it set, the SDK never auto-collects the token. iOS has
+nothing to opt out of: automatic forwarding is off unless you opt in via `Info.plist`. For full
+details, see the native
+[Android](https://github.com/klaviyo/klaviyo-android-sdk#Push-Notifications) and
+[iOS](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications) push documentation.
+
 #### React Native Token Collection
 
 In order to collect the APNs push token in your React Native code you need to:


### PR DESCRIPTION
# Description

Adopt the native Android default-ON `automatic_push_token_forwarding` change (MAGE-937) in the React Native wrapper documentation, and document the resulting per-platform default divergence. **Docs-only** — the native Android SDK pin bump to 4.5.0 lands in a separate PR.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — documentation-only change (no code).
- [ ] I have added sufficient unit/integration tests of my changes.
  - N/A — documentation-only change.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - Docs explicitly describe the intentional per-platform divergence (Android default-ON, iOS opt-in), verified against the native `feat/auto-push-tracking` branches on both platforms.

## Release/Versioning Considerations

<!-- Please add the planned version as a `milestone` label on this PR -->

- [ ] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Targeting `feat/auto-push-tracking` so docs only go live on the v2.5.0 release (which will carry the native Android 4.5.0 pin bump).
- [x] This is planned work for an upcoming release (v2.5.0).

## Changelog / Code Overview

**`README.md`** — New `#### Automatic Token Forwarding (Platform Defaults)` subsection under *Collecting Push Tokens*:
- **Android — on by default:** the native SDK auto-registers `KlaviyoPushService` via manifest merge and forwards the FCM token automatically.
- **iOS — opt-in (off by default):** relies on app-delegate method swizzling; token is set manually by default, with a pointer to the native iOS README for the `Info.plist` opt-in.
- Android manifest `com.klaviyo.push.automatic_push_token_forwarding="false"` opt-out documented as the single, complete opt-out.
- Manual token collection kept as the recommended baseline; automatic is additive.

**`MIGRATION_GUIDE.md`** — New `## Migrating to v2.5.0` entry: the default change, per-platform opt-out, double-collection-is-harmless note, and a forward-looking heads-up that a future **major** release may enable both push flags by default (opt-out, not opt-in, at that point).

## Test Plan

Documentation-only; no runtime behavior changes in this PR. Reviewer verification:
1. Render `README.md` and `MIGRATION_GUIDE.md` on the branch; confirm the new sections read correctly and code fences / links render.
2. Confirm technical accuracy against native behavior: Android `automatic_push_token_forwarding` defaults ON (MAGE-937); iOS opt-in via `Info.plist` (swift `feat/auto-push-tracking`).

## Related Issues/Tickets

- [MAGE-938](https://linear.app/klaviyo/issue/MAGE-938) — SDK Wrappers: adopt Android default-ON token forwarding + document divergence
- Blocked-by: MAGE-937 (native Android default-ON)
- Related: MAGE-907 (wrapper README push-open-tracking), MAGE-897 (native migration-guide wording), MAGE-774 (Expo opt-out prop — Expo docs deferred there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented updated push-token forwarding defaults for Android and iOS.
  * Added Android opt-out instructions and iOS opt-in guidance.
  * Clarified that manual token handling remains supported and duplicate tokens are avoided.
  * Added migration guidance for version 2.5.0 and noted potential future default changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->