### PR TITLE
feat: SDK Automatic Push Behavior Integration (rel/2.5.0)

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,6 +2,46 @@
 
 This guide outlines how developers can migrate from older versions of our SDK to newer ones.
 
+## Migrating to v2.5.0
+
+### Automatic push token forwarding is now the default on Android
+
+As of v2.5.0 (which pins the native Android SDK to 4.5.0), the Klaviyo SDK forwards the Android FCM
+push token to Klaviyo **automatically by default**. This formalizes behavior the bundled
+`KlaviyoPushService` already performed, and is **non-breaking** — the default preserves existing
+behavior.
+
+**iOS is unchanged:** automatic forwarding remains opt-in (off by default), because iOS token
+collection relies on the more invasive app-delegate method swizzling. The flag's semantics are
+identical across platforms (`false` = no automatic collection); only the per-platform default
+differs, for these platform-specific reasons.
+
+**No action is required** to keep current behavior. If you prefer to own the push-token pipeline
+yourself:
+
+- **Android** — disable automatic forwarding by adding this `meta-data` to the `<application>`
+  element of your `AndroidManifest.xml`, then continue calling `Klaviyo.setPushToken(...)` yourself:
+
+  ```xml
+  <meta-data
+      android:name="com.klaviyo.push.automatic_push_token_forwarding"
+      android:value="false" />
+  ```
+
+- **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
+  native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
+
+If you already collect and set the token manually on Android, no change is needed — duplicate tokens
+are deduplicated and cause no extra network request. See the
+[README](./README.md#collecting-push-tokens) for full token-collection guidance.
+
+> **Looking ahead:** a future **major** release may enable **both** `automatic_push_open_tracking`
+> and `automatic_push_token_forwarding` by default on all platforms, bringing automatic push
+> integration to parity. If that happens, apps that prefer to manage push integration manually would
+> need to **opt out** of the enabled defaults (as described above for Android), rather than opt in.
+> This is a non-breaking, forward-looking heads-up — nothing changes until that release, and we will
+> document the exact opt-out steps in its migration guide.
+
 ## Migrating to v2.0.0
 
 ### In-App Forms

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -32,8 +32,8 @@ yourself:
 - **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
   native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
 
-If you already collect and set the token manually on Android, no change is needed — repeated
-registrations with the same push request state are suppressed by the native SDK. See the
+If you already collect and set the token manually on Android, no change is needed — the native SDK
+only sends a request when the complete push request state has changed. See the
 [README](./README.md#collecting-push-tokens) for full token-collection guidance.
 
 > **Looking ahead:** a future **major** release may enable **both** `automatic_push_open_tracking`

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -12,9 +12,10 @@ push token to Klaviyo **automatically by default**. This formalizes behavior the
 behavior.
 
 **iOS is unchanged:** automatic forwarding remains opt-in (off by default), because iOS token
-collection relies on the more invasive app-delegate method swizzling. The flag's semantics are
-identical across platforms (`false` = no automatic collection); only the per-platform default
-differs, for these platform-specific reasons.
+collection relies on the more invasive app-delegate method swizzling. Each platform has its own key —
+`klaviyo_automatic_push_token_forwarding` in the iOS `Info.plist` and
+`com.klaviyo.push.automatic_push_token_forwarding` in the Android manifest — with the same meaning
+(`false` = no automatic collection) but different defaults, for these platform-specific reasons.
 
 **No action is required** to keep current behavior. If you prefer to own the push-token pipeline
 yourself:
@@ -31,8 +32,8 @@ yourself:
 - **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
   native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
 
-If you already collect and set the token manually on Android, no change is needed — duplicate tokens
-are deduplicated and cause no extra network request. See the
+If you already collect and set the token manually on Android, no change is needed — repeated
+registrations with the same push request state are suppressed by the native SDK. See the
 [README](./README.md#collecting-push-tokens) for full token-collection guidance.
 
 > **Looking ahead:** a future **major** release may enable **both** `automatic_push_open_tracking`

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,8 +8,9 @@ This guide outlines how developers can migrate from older versions of our SDK to
 
 As of v2.5.0 (which pins the native Android SDK to 4.5.0), the Klaviyo SDK forwards the Android FCM
 push token to Klaviyo **automatically by default**. This formalizes behavior the bundled
-`KlaviyoPushService` already performed, and is **non-breaking** — the default preserves existing
-behavior.
+`KlaviyoPushService` already performed — see the native
+[Android SDK README](https://github.com/klaviyo/klaviyo-android-sdk#Push-Notifications) for details —
+and is **non-breaking**, because the default preserves existing behavior.
 
 **iOS is unchanged:** automatic forwarding remains opt-in (off by default), because iOS token
 collection relies on the more invasive app-delegate method swizzling. Each platform has its own key —

--- a/README.md
+++ b/README.md
@@ -295,6 +295,42 @@ Push tokens can be collected either from your app's react native code or in the 
 Below sections discuss both approaches, and you are free to pick one that best suits your app's architecture.
 Note that doing this in one location is sufficient.
 
+#### Automatic Token Forwarding (Platform Defaults)
+
+Before choosing an approach, note that the underlying native SDKs handle automatic push-token
+forwarding differently by default:
+
+- **Android — on by default.** The native Android SDK auto-registers its `KlaviyoPushService`
+  (a `FirebaseMessagingService`) via manifest merge, so it forwards the FCM token to Klaviyo
+  automatically, without any React Native code. You do not need to collect the token yourself on
+  Android — though doing so is harmless (duplicate tokens are deduplicated and cause no extra
+  network request).
+- **iOS — opt-in (off by default).** iOS token forwarding relies on app-delegate method swizzling,
+  which is more invasive, so the native iOS SDK does not enable it implicitly. By default you set the
+  APNs token manually, as shown below. Automatic forwarding on iOS is opt-in via `Info.plist` — see
+  the native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications).
+
+The flag's semantics are identical on both platforms (`false` = no automatic collection); only the
+default differs, for these platform-specific reasons. Manual token collection (documented below)
+remains the recommended baseline and works on both platforms — automatic forwarding is additive, not
+a replacement.
+
+To **opt out** of automatic forwarding on Android, add the following `meta-data` to the
+`<application>` element of your app's `AndroidManifest.xml` (which your app owns), then register the
+token yourself via `Klaviyo.setPushToken(...)`:
+
+```xml
+<meta-data
+    android:name="com.klaviyo.push.automatic_push_token_forwarding"
+    android:value="false" />
+```
+
+This is the single, complete opt-out — with it set, the SDK never auto-collects the token. iOS has
+nothing to opt out of: automatic forwarding is off unless you opt in via `Info.plist`. For full
+details, see the native
+[Android](https://github.com/klaviyo/klaviyo-android-sdk#Push-Notifications) and
+[iOS](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications) push documentation.
+
 #### React Native Token Collection
 
 In order to collect the APNs push token in your React Native code you need to:

--- a/README.md
+++ b/README.md
@@ -479,9 +479,9 @@ us from bridging this functionality into the React Native SDK code.
 - [Android](https://github.com/klaviyo/klaviyo-android-sdk#Tracking-Open-Events)
 - [iOS](https://github.com/klaviyo/klaviyo-swift-sdk#Tracking-Open-Events)
 
-As an alternative to the handler-based setup in those guides, the native SDKs offer an **opt-in
-automatic push-open tracking mode**, declared in your native configuration rather than written in
-code: `klaviyo_automatic_push_open_tracking` in the iOS `Info.plist` and
+As an alternative to the handler-based setup in those guides, the native SDKs pinned by v2.5.0 offer
+an **opt-in automatic push-open tracking mode**, declared in your native configuration rather than
+written in code: `klaviyo_automatic_push_open_tracking` in the iOS `Info.plist` and
 `com.klaviyo.push.automatic_push_open_tracking` in the Android manifest. It is off by default, and is
 independent of automatic token forwarding — you can enable either, both, or neither. See the
 platform guides above for how each mode works and what it changes.

--- a/README.md
+++ b/README.md
@@ -303,17 +303,18 @@ forwarding differently by default:
 - **Android — on by default.** The native Android SDK auto-registers its `KlaviyoPushService`
   (a `FirebaseMessagingService`) via manifest merge, so it forwards the FCM token to Klaviyo
   automatically, without any React Native code. You do not need to collect the token yourself on
-  Android — though doing so is harmless (duplicate tokens are deduplicated and cause no extra
-  network request).
+  Android — though doing so is harmless: repeated registrations with the same push request state are
+  suppressed by the native SDK.
 - **iOS — opt-in (off by default).** iOS token forwarding relies on app-delegate method swizzling,
   which is more invasive, so the native iOS SDK does not enable it implicitly. By default you set the
   APNs token manually, as shown below. Automatic forwarding on iOS is opt-in via `Info.plist` — see
   the native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications).
 
-The flag's semantics are identical on both platforms (`false` = no automatic collection); only the
-default differs, for these platform-specific reasons. Manual token collection (documented below)
-remains the recommended baseline and works on both platforms — automatic forwarding is additive, not
-a replacement.
+Each platform has its own key — `klaviyo_automatic_push_token_forwarding` in the iOS `Info.plist` and
+`com.klaviyo.push.automatic_push_token_forwarding` in the Android manifest — with the same meaning
+(`false` = no automatic collection) but different defaults, for these platform-specific reasons.
+Manual token collection (documented below) remains the recommended baseline and works on both
+platforms — automatic forwarding is additive, not a replacement.
 
 To **opt out** of automatic forwarding on Android, add the following `meta-data` to the
 `<application>` element of your app's `AndroidManifest.xml` (which your app owns), then register the
@@ -325,9 +326,9 @@ token yourself via `Klaviyo.setPushToken(...)`:
     android:value="false" />
 ```
 
-This is the single, complete opt-out — with it set, the SDK never auto-collects the token. iOS has
-nothing to opt out of: automatic forwarding is off unless you opt in via `Info.plist`. For full
-details, see the native
+On Android this is the complete opt-out — with it set, the native SDK never auto-collects the token,
+though any token already registered remains until you replace it. iOS has nothing to opt out of:
+automatic forwarding is off unless you opt in via `Info.plist`. For full details, see the native
 [Android](https://github.com/klaviyo/klaviyo-android-sdk#Push-Notifications) and
 [iOS](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications) push documentation.
 

--- a/README.md
+++ b/README.md
@@ -479,6 +479,13 @@ us from bridging this functionality into the React Native SDK code.
 - [Android](https://github.com/klaviyo/klaviyo-android-sdk#Tracking-Open-Events)
 - [iOS](https://github.com/klaviyo/klaviyo-swift-sdk#Tracking-Open-Events)
 
+As an alternative to the handler-based setup in those guides, the native SDKs offer an **opt-in
+automatic push-open tracking mode**, declared in your native configuration rather than written in
+code: `klaviyo_automatic_push_open_tracking` in the iOS `Info.plist` and
+`com.klaviyo.push.automatic_push_open_tracking` in the Android manifest. It is off by default, and is
+independent of automatic token forwarding — you can enable either, both, or neither. See the
+platform guides above for how each mode works and what it changes.
+
 > Note: If you initialize Klaviyo from React Native code, be aware that on both platforms the timing of when
 > an `Opened Push` event gets triggered can sometimes occur before your React Native code to initialize our SDK
 > can execute. To mitigate this, our SDK holds the request in memory until initialization occurs.

--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ forwarding differently by default:
 - **Android — on by default.** The native Android SDK auto-registers its `KlaviyoPushService`
   (a `FirebaseMessagingService`) via manifest merge, so it forwards the FCM token to Klaviyo
   automatically, without any React Native code. You do not need to collect the token yourself on
-  Android — though doing so is harmless: repeated registrations with the same push request state are
-  suppressed by the native SDK.
+  Android — though doing so is harmless: the native SDK only sends a request when the complete push
+  request state has changed.
 - **iOS — opt-in (off by default).** iOS token forwarding relies on app-delegate method swizzling,
   which is more invasive, so the native iOS SDK does not enable it implicitly. By default you set the
   APNs token manually, as shown below. Automatic forwarding on iOS is opt-in via `Info.plist` — see


### PR DESCRIPTION
Contains all of the commits for the automatic sdk integration project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added v2.5.0 migration guidance for automatic push-token forwarding.
  * Documented platform-specific defaults: Android forwarding is enabled by default, while iOS remains opt-in.
  * Explained Android opt-out configuration, manual token compatibility, and duplicate-token handling.
  * Added guidance for optional automatic push-open tracking on Android and iOS, including configuration and default-disabled behavior.
  * Included native SDK references and potential future default changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->