### PR TITLE
chore(release): bump version to 2.5.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,7 +17,8 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.5.0
+# saved: 4.5.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=rel~4.5.0-SNAPSHOT
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,7 +21,7 @@ android.useAndroidX=true
 # Klaviyo.createSubscription ships in 4.5.0, which is cut on rel/4.5.0 but not yet released.
 # JitPack (declared as a repository in android/build.gradle) builds the branch on demand under
 # the same group; '/' is escaped as '~' in the version string.
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=rel~4.5.0-SNAPSHOT
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.5.0
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,7 +17,7 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.4.0
+KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.5.0
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23
 KlaviyoReactNativeSdk_targetSdkVersion=36

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.4.1</string>
+  <string name="klaviyo_sdk_version_override">2.5.0</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.4.1"
+        versionName "2.5.0"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -39,6 +39,10 @@ target 'KlaviyoReactNativeSdkExample' do
   use_frameworks! :linkage => :static
 
   # Insert override klaviyo-swift-sdk pods below this line when needed
+  pod 'KlaviyoCore', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
+  pod 'KlaviyoSwift', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
+  pod 'KlaviyoForms', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
+  pod 'KlaviyoLocation', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
 
   # Setup permissions for react-native-permissions
   setup_permissions([
@@ -78,6 +82,6 @@ end
 target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
   # Insert override klaviyo-swift-sdk extension pod below this line when needed
-  pod 'KlaviyoSwiftExtension'
+  pod 'KlaviyoSwiftExtension', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -47,10 +47,6 @@ target 'KlaviyoReactNativeSdkExample' do
   # Once 5.4.0 releases, remove these overrides and restore the podspec version pins
   # via `./configure-sdk.sh -r --ios=5.4.0`.
   klaviyo_swift_sdk = { :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0' }
-  pod 'KlaviyoCore', **klaviyo_swift_sdk
-  pod 'KlaviyoSwift', **klaviyo_swift_sdk
-  pod 'KlaviyoForms', **klaviyo_swift_sdk
-  pod 'KlaviyoLocation', **klaviyo_swift_sdk
 
   # Setup permissions for react-native-permissions
   setup_permissions([
@@ -90,8 +86,8 @@ end
 target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
   # Insert override klaviyo-swift-sdk extension pod below this line when needed
+  pod 'KlaviyoSwiftExtension'
   # TODO(MAGE-874, MAGE-856): temporary rel/5.4.0 branch pin — remove alongside the
   # overrides on the main target above once 5.4.0 publishes. See the note there.
-  pod 'KlaviyoSwiftExtension', :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0'
 end
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -38,6 +38,8 @@ target 'KlaviyoReactNativeSdkExample' do
 
   use_frameworks! :linkage => :static
 
+  # Insert override klaviyo-swift-sdk pods below this line when needed
+
   # Setup permissions for react-native-permissions
   setup_permissions([
     'LocationWhenInUse',

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -38,16 +38,6 @@ target 'KlaviyoReactNativeSdkExample' do
 
   use_frameworks! :linkage => :static
 
-  # Insert override klaviyo-swift-sdk pods below this line when needed
-  # TODO(MAGE-874, MAGE-856): temporary pin to the rel/5.4.0 branch until KlaviyoSwift
-  # 5.4.0 is released. Both setLoggingEnabled/isLoggingEnabled (MAGE-874) and
-  # create(subscription:) (MAGE-856) ship in 5.4.0, which is cut on rel/5.4.0 but not
-  # yet published to CocoaPods trunk. Declared here rather than in
-  # klaviyo-react-native-sdk.podspec so the override can never reach integrators.
-  # Once 5.4.0 releases, remove these overrides and restore the podspec version pins
-  # via `./configure-sdk.sh -r --ios=5.4.0`.
-  klaviyo_swift_sdk = { :git => 'https://github.com/klaviyo/klaviyo-swift-sdk.git', :branch => 'rel/5.4.0' }
-
   # Setup permissions for react-native-permissions
   setup_permissions([
     'LocationWhenInUse',
@@ -87,7 +77,5 @@ target 'KlaviyoReactNativeSdkExampleExtension' do
   use_frameworks! :linkage => :static
   # Insert override klaviyo-swift-sdk extension pod below this line when needed
   pod 'KlaviyoSwiftExtension'
-  # TODO(MAGE-874, MAGE-856): temporary rel/5.4.0 branch pin — remove alongside the
-  # overrides on the main target above once 5.4.0 publishes. See the note there.
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,21 +63,21 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.4.0):
-    - KlaviyoForms (= 5.3.1)
-    - KlaviyoLocation (= 5.3.1)
-    - KlaviyoSwift (= 5.3.1)
+  - klaviyo-react-native-sdk (2.5.0):
+    - KlaviyoForms
+    - KlaviyoLocation
+    - KlaviyoSwift
     - React-Core
-  - KlaviyoCore (5.3.1):
+  - KlaviyoCore (5.4.0):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.3.1):
-    - KlaviyoSwift (~> 5.3.1)
-  - KlaviyoLocation (5.3.1):
-    - KlaviyoSwift (~> 5.3.1)
-  - KlaviyoSwift (5.3.1):
+  - KlaviyoForms (5.4.0):
+    - KlaviyoCore (~> 5.4.0)
+  - KlaviyoLocation (5.4.0):
+    - KlaviyoSwift (~> 5.4.0)
+  - KlaviyoSwift (5.4.0):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.3.1)
-  - KlaviyoSwiftExtension (5.3.1)
+    - KlaviyoCore (~> 5.4.0)
+  - KlaviyoSwiftExtension (5.4.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -1825,92 +1825,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
   - react-native-safe-area-context (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - react-native-safe-area-context/common (= 5.6.2)
-    - react-native-safe-area-context/fabric (= 5.6.2)
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - react-native-safe-area-context/common (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - react-native-safe-area-context/fabric (5.6.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - react-native-safe-area-context/common
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - React-NativeModulesApple (0.81.5):
     - boost
     - DoubleConversion
@@ -2417,33 +2332,7 @@ PODS:
     - React-utils (= 0.81.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - RNFBApp (24.0.0):
     - boost
     - DoubleConversion
@@ -2505,33 +2394,7 @@ PODS:
     - SocketRocket
     - Yoga
   - RNPermissions (5.4.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2544,7 +2407,11 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
-  - KlaviyoSwiftExtension
+  - KlaviyoCore (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
+  - KlaviyoForms (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
+  - KlaviyoLocation (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
+  - KlaviyoSwift (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
+  - KlaviyoSwiftExtension (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -2628,11 +2495,6 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
-    - KlaviyoCore
-    - KlaviyoForms
-    - KlaviyoLocation
-    - KlaviyoSwift
-    - KlaviyoSwiftExtension
     - nanopb
     - PromisesObjC
     - SocketRocket
@@ -2655,6 +2517,21 @@ EXTERNAL SOURCES:
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
   klaviyo-react-native-sdk:
     :path: "../.."
+  KlaviyoCore:
+    :branch: rel/5.4.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoForms:
+    :branch: rel/5.4.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoLocation:
+    :branch: rel/5.4.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwift:
+    :branch: rel/5.4.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwiftExtension:
+    :branch: rel/5.4.0
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2794,6 +2671,23 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
+CHECKOUT OPTIONS:
+  KlaviyoCore:
+    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoForms:
+    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoLocation:
+    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwift:
+    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+  KlaviyoSwiftExtension:
+    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
+
 SPEC CHECKSUMS:
   AnyCodable-FlightSchool: 261cbe76757802b17d471b9059b21e6fa5edf57b
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -2811,15 +2705,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 021a6341807e8cbc03e595e5b499276cb115c641
-  KlaviyoCore: 37750d289e7113277899f6a2c9f8f088e732d869
-  KlaviyoForms: 7e69da16880700be263b819e542255d2b639507a
-  KlaviyoLocation: 07b9a74ebcef661310b22f4be6ebd0e03c816793
-  KlaviyoSwift: 5406447e2e594c47c80d9442c67ac088b92cc77e
-  KlaviyoSwiftExtension: cf8257a28734e076224560fe7379a8eb6aa94270
+  klaviyo-react-native-sdk: 0af83aa3bbef0a679b604a34ae966258b3f3ff0f
+  KlaviyoCore: a28031c37a32e4d22550004c407d88c561a6e67b
+  KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
+  KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
+  KlaviyoSwift: 8fd0bf6732e042dd06b52108d3eeae7960868192
+  KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788
@@ -2852,21 +2746,21 @@ SPEC CHECKSUMS:
   React-logger: a913317214a26565cd4c045347edf1bcacb80a3f
   React-Mapbuffer: 017336879e2e0fb7537bbc08c24f34e2384c9260
   React-microtasksnativemodule: 63ee6730cec233feab9cdcc0c100dc28a12e4165
-  react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8
+  react-native-safe-area-context: 6c8805194166a9d6b3e53ba69ca76756c9bfb052
   React-NativeModulesApple: cbceb3c4cb726838c461b13802a76cefa6f3476f
   React-oscompat: eb0626e8ba1a2c61673c991bf9dc21834898475d
   React-perflogger: 509e1f9a3ee28df71b0a66de806ac515ce951246
   React-performancetimeline: 9ce28cce1cded27410c293283f99fe62bebdb920
   React-RCTActionSheet: 30fe8f9f8d86db4a25ff34595a658ecd837485fc
   React-RCTAnimation: 3126eb1cb8e7a6ca33a52fd833d8018aa9311af1
-  React-RCTAppDelegate: b03981c790aa40cf26e0f78cc0f1f2df8287ead4
+  React-RCTAppDelegate: 580873aef88cf9f054559f53193333c64844ed02
   React-RCTBlob: 53c35e85c85d6bdaa55dc81a0b290d4e78431095
-  React-RCTFabric: 59ad9008775f123019c508efff260594a8509791
-  React-RCTFBReactNativeSpec: 82b605ab4f6f8da0a7ad88641161df5a0bafb1fb
+  React-RCTFabric: 3e9792e3bd990d1d08ae8843fef4674c06bb55fe
+  React-RCTFBReactNativeSpec: 82ba93954801bf0998f0a8a3ffbb14c8b29fbad1
   React-RCTImage: 074b2faa71a152a456c974e118b60c9eeda94a64
   React-RCTLinking: e5ca17a4f7ae2ad7b0c0483be77e1b383ecd0a8a
   React-RCTNetwork: c508d7548c9eceac30a8100a846ea00033a03366
-  React-RCTRuntime: 6979568c0bc276fe785e085894f954fa15e0ec7e
+  React-RCTRuntime: 2f4bfa224424f532120fed792f77b6fe0c328d53
   React-RCTSettings: dd84c857a4fce42c1e08c1dabcda894e25af4a6e
   React-RCTText: 6e4b177d047f98bccb90d6fb1ebdd3391cf8b299
   React-RCTVibration: 9572d4a06a0c92650bcc62913e50eb2a89f19fb6
@@ -2883,13 +2777,13 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 2e921a931c5a4dd1d8ab37ade085fdf58fcfe1dd
   ReactCommon: 6d0fa86a4510730da7c72560e0ced14258292ab9
-  RNCAsyncStorage: fd44f4b03e007e642e98df6726737bc66e9ba609
-  RNFBApp: 59a5f1280d8c7d48ed5cb658682ed12904bca65e
-  RNFBMessaging: 296600da7f02e92bb6631c11ef5e19bc1b89a54d
-  RNPermissions: 3cd4b57620639fed3e31c3423228e5fd2f897fe8
+  RNCAsyncStorage: b44e8a4e798c3e1f56bffccd0f591f674fb9198f
+  RNFBApp: 9c5758c26b894c173b5fc29b6a576e448a824a47
+  RNFBMessaging: a263c04f305639e6d75df6787b0dfefe8eb2952e
+  RNPermissions: b86f5af66b9ab0c0ab7cdb2c63dea4095664b2bd
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: 1ab968cc8cc5357131b42b0efa05d7865588a201
+PODFILE CHECKSUM: bb3fdf4838abc8b0326d9f8f976172970a516748
 
 COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -64,9 +64,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
   - klaviyo-react-native-sdk (2.5.0):
-    - KlaviyoForms
-    - KlaviyoLocation
-    - KlaviyoSwift
+    - KlaviyoForms (= 5.4.0)
+    - KlaviyoLocation (= 5.4.0)
+    - KlaviyoSwift (= 5.4.0)
     - React-Core
   - KlaviyoCore (5.4.0):
     - AnyCodable-FlightSchool
@@ -2544,11 +2544,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - klaviyo-react-native-sdk (from `../..`)
-  - KlaviyoCore (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
-  - KlaviyoForms (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
-  - KlaviyoLocation (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
-  - KlaviyoSwift (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
-  - KlaviyoSwiftExtension (from `https://github.com/klaviyo/klaviyo-swift-sdk.git`, branch `rel/5.4.0`)
+  - KlaviyoSwiftExtension
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -2632,6 +2628,11 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
+    - KlaviyoCore
+    - KlaviyoForms
+    - KlaviyoLocation
+    - KlaviyoSwift
+    - KlaviyoSwiftExtension
     - nanopb
     - PromisesObjC
     - SocketRocket
@@ -2654,21 +2655,6 @@ EXTERNAL SOURCES:
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
   klaviyo-react-native-sdk:
     :path: "../.."
-  KlaviyoCore:
-    :branch: rel/5.4.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoForms:
-    :branch: rel/5.4.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoLocation:
-    :branch: rel/5.4.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwift:
-    :branch: rel/5.4.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwiftExtension:
-    :branch: rel/5.4.0
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2808,23 +2794,6 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
-CHECKOUT OPTIONS:
-  KlaviyoCore:
-    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoForms:
-    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoLocation:
-    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwift:
-    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-  KlaviyoSwiftExtension:
-    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
-    :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
-
 SPEC CHECKSUMS:
   AnyCodable-FlightSchool: 261cbe76757802b17d471b9059b21e6fa5edf57b
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
@@ -2842,15 +2811,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 0af83aa3bbef0a679b604a34ae966258b3f3ff0f
-  KlaviyoCore: a28031c37a32e4d22550004c407d88c561a6e67b
+  klaviyo-react-native-sdk: 964b9055637c18a7231e8e73372ebb1cd945deb0
+  KlaviyoCore: 4b87a84a10a44110b4ec73459d91f63941bedb47
   KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
   KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 033c34890cac7bb85cd57aecee0785d492de76f3
+  KlaviyoSwift: 07ddea8bee2a80a5e8e25e23231008eb59f2da71
   KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788
@@ -2921,6 +2890,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: f60dc2836360857c50c15882dba49fe0de4eeba5
+PODFILE CHECKSUM: 311a4bbf254241596bfd0ef834585e0dd986b5ed
 
 COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1825,7 +1825,92 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
   - react-native-safe-area-context (5.6.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common (= 5.6.2)
+    - react-native-safe-area-context/fabric (= 5.6.2)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/common (5.6.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/fabric (5.6.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - React-NativeModulesApple (0.81.5):
     - boost
     - DoubleConversion
@@ -2332,7 +2417,33 @@ PODS:
     - React-utils (= 0.81.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNFBApp (24.0.0):
     - boost
     - DoubleConversion
@@ -2394,7 +2505,33 @@ PODS:
     - SocketRocket
     - Yoga
   - RNPermissions (5.4.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2673,19 +2810,19 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KlaviyoCore:
-    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
     :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   KlaviyoForms:
-    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
     :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   KlaviyoLocation:
-    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
     :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   KlaviyoSwift:
-    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
     :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
   KlaviyoSwiftExtension:
-    :commit: 1f13664ff83c33008ab01321c2fd45b345fd1ae9
+    :commit: 8cc1c9034be988783c0745e652426e17e7b85802
     :git: https://github.com/klaviyo/klaviyo-swift-sdk.git
 
 SPEC CHECKSUMS:
@@ -2709,7 +2846,7 @@ SPEC CHECKSUMS:
   KlaviyoCore: a28031c37a32e4d22550004c407d88c561a6e67b
   KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
   KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 8fd0bf6732e042dd06b52108d3eeae7960868192
+  KlaviyoSwift: 033c34890cac7bb85cd57aecee0785d492de76f3
   KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -2746,21 +2883,21 @@ SPEC CHECKSUMS:
   React-logger: a913317214a26565cd4c045347edf1bcacb80a3f
   React-Mapbuffer: 017336879e2e0fb7537bbc08c24f34e2384c9260
   React-microtasksnativemodule: 63ee6730cec233feab9cdcc0c100dc28a12e4165
-  react-native-safe-area-context: 6c8805194166a9d6b3e53ba69ca76756c9bfb052
+  react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8
   React-NativeModulesApple: cbceb3c4cb726838c461b13802a76cefa6f3476f
   React-oscompat: eb0626e8ba1a2c61673c991bf9dc21834898475d
   React-perflogger: 509e1f9a3ee28df71b0a66de806ac515ce951246
   React-performancetimeline: 9ce28cce1cded27410c293283f99fe62bebdb920
   React-RCTActionSheet: 30fe8f9f8d86db4a25ff34595a658ecd837485fc
   React-RCTAnimation: 3126eb1cb8e7a6ca33a52fd833d8018aa9311af1
-  React-RCTAppDelegate: 580873aef88cf9f054559f53193333c64844ed02
+  React-RCTAppDelegate: b03981c790aa40cf26e0f78cc0f1f2df8287ead4
   React-RCTBlob: 53c35e85c85d6bdaa55dc81a0b290d4e78431095
-  React-RCTFabric: 3e9792e3bd990d1d08ae8843fef4674c06bb55fe
-  React-RCTFBReactNativeSpec: 82ba93954801bf0998f0a8a3ffbb14c8b29fbad1
+  React-RCTFabric: 59ad9008775f123019c508efff260594a8509791
+  React-RCTFBReactNativeSpec: 82b605ab4f6f8da0a7ad88641161df5a0bafb1fb
   React-RCTImage: 074b2faa71a152a456c974e118b60c9eeda94a64
   React-RCTLinking: e5ca17a4f7ae2ad7b0c0483be77e1b383ecd0a8a
   React-RCTNetwork: c508d7548c9eceac30a8100a846ea00033a03366
-  React-RCTRuntime: 2f4bfa224424f532120fed792f77b6fe0c328d53
+  React-RCTRuntime: 6979568c0bc276fe785e085894f954fa15e0ec7e
   React-RCTSettings: dd84c857a4fce42c1e08c1dabcda894e25af4a6e
   React-RCTText: 6e4b177d047f98bccb90d6fb1ebdd3391cf8b299
   React-RCTVibration: 9572d4a06a0c92650bcc62913e50eb2a89f19fb6
@@ -2777,13 +2914,13 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
   ReactCodegen: 2e921a931c5a4dd1d8ab37ade085fdf58fcfe1dd
   ReactCommon: 6d0fa86a4510730da7c72560e0ced14258292ab9
-  RNCAsyncStorage: b44e8a4e798c3e1f56bffccd0f591f674fb9198f
-  RNFBApp: 9c5758c26b894c173b5fc29b6a576e448a824a47
-  RNFBMessaging: a263c04f305639e6d75df6787b0dfefe8eb2952e
-  RNPermissions: b86f5af66b9ab0c0ab7cdb2c63dea4095664b2bd
+  RNCAsyncStorage: fd44f4b03e007e642e98df6726737bc66e9ba609
+  RNFBApp: 59a5f1280d8c7d48ed5cb658682ed12904bca65e
+  RNFBMessaging: 296600da7f02e92bb6631c11ef5e19bc1b89a54d
+  RNPermissions: 3cd4b57620639fed3e31c3423228e5fd2f897fe8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: bb3fdf4838abc8b0326d9f8f976172970a516748
+PODFILE CHECKSUM: f60dc2836360857c50c15882dba49fe0de4eeba5
 
 COCOAPODS: 1.16.2

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.4.1</string>
+	<string>2.5.0</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.4.0"
+  s.dependency "KlaviyoSwift" ##, "5.4.0"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.4.0"
+    s.dependency "KlaviyoLocation" ##, "5.4.0"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.4.0"
+    s.dependency "KlaviyoForms" ##, "5.4.0"
   end
 
   s.default_subspecs = :none

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.3.1"
+  s.dependency "KlaviyoSwift", "5.4.0"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.3.1"
+    s.dependency "KlaviyoLocation", "5.4.0"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.3.1"
+    s.dependency "KlaviyoForms", "5.4.0"
   end
 
   s.default_subspecs = :none

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift" ##, "5.4.0"
+  s.dependency "KlaviyoSwift", "5.4.0"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation" ##, "5.4.0"
+    s.dependency "KlaviyoLocation", "5.4.0"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms" ##, "5.4.0"
+    s.dependency "KlaviyoForms", "5.4.0"
   end
 
   s.default_subspecs = :none

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
## Summary

Bumps the React Native SDK **2.4.1 -> 2.5.0** and re-pins the native SDK dependencies to the Q2 release versions.

Generated via the repo's own script:
```
./bump-version.sh -v 2.5.0 -a 4.5.0 -s 5.4.0 --skip-install
```
`--skip-install` was used because the native artifacts are not published yet (see below); the version/pin edits are produced without a `pod update` / `yarn install`.

## Changelog

- **RN SDK version** `package.json`, `ios/klaviyo-sdk-configuration.plist` (`klaviyo_sdk_version`), `android/src/main/res/values/strings.xml` (`klaviyo_sdk_version_override`) -> 2.5.0; example app `versionName` + `MARKETING_VERSION` -> 2.5.0
- **iOS native pins** `klaviyo-react-native-sdk.podspec`: `KlaviyoSwift`, `KlaviyoForms`, `KlaviyoLocation` `5.3.1` -> `5.4.0`
- **Android native pin** `android/gradle.properties`: `KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion 4.4.0` -> `4.5.0`

## Test plan

- [ ] `yarn install` (root + example) resolves
- [ ] `cd example/ios && bundle exec pod update KlaviyoSwift KlaviyoForms KlaviyoLocation` resolves against 5.4.0
- [ ] Example app builds on both platforms

## Blocked on upstream publish

Dependency resolution / CI will stay red until the native artifacts are published:
- iOS pins `5.4.0` need **KlaviyoSwift/KlaviyoForms/KlaviyoLocation 5.4.0 on the CocoaPods trunk**
- Android pin `4.5.0` resolves via **JitPack / Maven** once the `klaviyo-android-sdk` 4.5.0 tag/release exists

This is also the prerequisite for the Expo plugin release: once RN 2.5.0 is published to npm, `klaviyo-expo-plugin` can pin it. Hold merge until iOS 5.4.0 and Android 4.5.0 are released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 2.5.0 of the Klaviyo React Native SDK across Android and iOS.
  * Updated Android dependencies to the stable 4.5.0 SDK release.
  * Updated iOS dependencies to Klaviyo SDK version 5.4.0.
  * Updated example applications and platform configuration to reflect version 2.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->