### PR TITLE
ci: sign example TestFlight builds via fastlane match (fixes cert-cap failures)

### DIFF
--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -380,6 +380,11 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Password-protected distribution key: match imports keys with an empty
+          # password, which macOS 26's `security import` rejects, so the lane
+          # imports this one itself. See example/fastlane/Fastfile.
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           # RN build-phase scripts read this directly to wire codegen outputs.
           RCT_NEW_ARCH_ENABLED: '1'
           # Prevent Metro from starting a dev server.
@@ -390,6 +395,9 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           eval "$(ssh-agent -s)"
           printf '%s\n' "$MATCH_DEPLOY_KEY" | ssh-add -
+          CERT_P12_PATH="$RUNNER_TEMP/dist.p12"
+          echo "$BUILD_CERTIFICATE_BASE64" | base64 -d > "$CERT_P12_PATH"
+          export CERT_P12_PATH
           fastlane ios release_ipa
 
       # altool with the API key — no Apple ID / app-specific password / 2FA dance.

--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -360,29 +360,52 @@ jobs:
         shell: bash
         run: xcrun agvtool new-version -all "$BUILD_NUMBER"
 
-      # Team ID is stamped from a secret (checked-in plist uses a placeholder).
-      # signingCertificate is forced to "Apple Distribution" so exportArchive
-      # doesn't fall back to the legacy "iOS Distribution" cert family.
+      # Pull the shared App Store cert + provisioning profiles from the
+      # mobile-certificates match repo into an ephemeral keychain. readonly =>
+      # git-only, no Apple portal calls, so no certificate is ever generated
+      # (replaces cloud-managed signing that was exhausting the cert cap).
+      # ssh-agent is started inline because its env can't cross workflow steps,
+      # and `fastlane` is preinstalled on the macOS runner.
+      - name: Sync signing assets (match, readonly)
+        working-directory: example
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          eval "$(ssh-agent -s)"
+          printf '%s\n' "$MATCH_DEPLOY_KEY" | ssh-add -
+          fastlane ios sync_signing
+
+      # Manual signing driven by the match-installed profiles. Profile names
+      # follow match's convention ("match AppStore <bundle-id>"); the single
+      # distribution identity match imported is auto-selected, so no
+      # signingCertificate override is needed. Team ID is stamped from a secret
+      # (the checked-in plist uses a placeholder).
       - name: Stamp signing config into ExportOptions.plist
         working-directory: example/ios
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         shell: bash
         run: |
-          /usr/libexec/PlistBuddy -c "Set :teamID ${APPLE_TEAM_ID}" ExportOptions.plist
-          # PlistBuddy errors on Add when the key exists, so try Add then Set.
-          /usr/libexec/PlistBuddy -c "Add :signingCertificate string Apple Distribution" ExportOptions.plist 2>/dev/null \
-            || /usr/libexec/PlistBuddy -c "Set :signingCertificate Apple Distribution" ExportOptions.plist
+          PB=/usr/libexec/PlistBuddy
+          P=ExportOptions.plist
+          $PB -c "Set :teamID ${APPLE_TEAM_ID}" $P
+          $PB -c "Set :signingStyle manual" $P
+          $PB -c 'Add :provisioningProfiles dict' $P 2>/dev/null || true
+          $PB -c 'Add :provisioningProfiles:com.klaviyoreactnativesdkexample string "match AppStore com.klaviyoreactnativesdkexample"' $P
+          $PB -c 'Add :provisioningProfiles:com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension string "match AppStore com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension"' $P
 
-      # Cloud-managed signing: -allowProvisioningUpdates lets xcodebuild
-      # register/refresh the distribution cert and provisioning profiles
-      # via App Store Connect using the API key flags.
+      # Manual signing using the match-installed identity + profiles. No
+      # -allowProvisioningUpdates / auth-key flags, so xcodebuild cannot reach
+      # App Store Connect to mint a certificate — it must use what match placed
+      # in the keychain and ~/Library/MobileDevice/Provisioning Profiles.
       - name: Archive
         working-directory: example/ios
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           # RN build-phase scripts read this directly to wire codegen outputs.
           RCT_NEW_ARCH_ENABLED: '1'
           # Prevent Metro from starting a dev server.
@@ -402,27 +425,17 @@ jobs:
             -configuration Release \
             -destination "generic/platform=iOS" \
             archive -archivePath KlaviyoReactNativeSdkExample.xcarchive \
-            -allowProvisioningUpdates \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8" \
+            CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID"
 
       - name: Export IPA
         working-directory: example/ios
-        env:
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
         shell: bash
         run: |
           xcodebuild -exportArchive \
             -archivePath KlaviyoReactNativeSdkExample.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
-            -exportPath ./build \
-            -allowProvisioningUpdates \
-            -authenticationKeyID "$ASC_KEY_ID" \
-            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
-            -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+            -exportPath ./build
 
       # altool with the API key — no Apple ID / app-specific password / 2FA dance.
       - name: Upload to TestFlight

--- a/.github/workflows/publish-example.yml
+++ b/.github/workflows/publish-example.yml
@@ -234,6 +234,14 @@ jobs:
           working-directory: example
           bundler-cache: true
 
+      # setup-ruby switches the job to the example's pinned Ruby, which hides the
+      # runner's preinstalled fastlane and doesn't have it as a gem. Install it
+      # explicitly into the active Ruby so `fastlane` resolves deterministically.
+      # Kept out of example/Gemfile to avoid bloating the CocoaPods-only bundle.
+      - name: Install fastlane
+        shell: bash
+        run: gem install fastlane -v 2.237.0 --no-document
+
       # Real GoogleService-Info.plist (com.klaviyoreactnativesdkexample) so
       # push delivery works against the published build.
       - name: Inject GoogleService-Info.plist
@@ -360,82 +368,29 @@ jobs:
         shell: bash
         run: xcrun agvtool new-version -all "$BUILD_NUMBER"
 
-      # Pull the shared App Store cert + provisioning profiles from the
-      # mobile-certificates match repo into an ephemeral keychain. readonly =>
-      # git-only, no Apple portal calls, so no certificate is ever generated
-      # (replaces cloud-managed signing that was exhausting the cert cap).
-      # ssh-agent is started inline because its env can't cross workflow steps,
-      # and `fastlane` is preinstalled on the macOS runner.
-      - name: Sync signing assets (match, readonly)
+      # Build + sign the IPA via fastlane. The `release_ipa` lane runs
+      # match(readonly) to install the shared App Store cert + profiles from the
+      # mobile-certificates repo (git-only, never contacts Apple, so no cert is
+      # generated), pins each target to its match profile, and exports a signed
+      # IPA to example/ios/build/. ssh-agent is started inline because its env
+      # can't cross workflow steps, and match runs in this same step.
+      - name: Build & sign IPA (fastlane match + gym)
         working-directory: example
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_DEPLOY_KEY: ${{ secrets.MATCH_DEPLOY_KEY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # RN build-phase scripts read this directly to wire codegen outputs.
+          RCT_NEW_ARCH_ENABLED: '1'
+          # Prevent Metro from starting a dev server.
+          CI: 'true'
         shell: bash
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           eval "$(ssh-agent -s)"
           printf '%s\n' "$MATCH_DEPLOY_KEY" | ssh-add -
-          fastlane ios sync_signing
-
-      # Manual signing driven by the match-installed profiles. Profile names
-      # follow match's convention ("match AppStore <bundle-id>"); the single
-      # distribution identity match imported is auto-selected, so no
-      # signingCertificate override is needed. Team ID is stamped from a secret
-      # (the checked-in plist uses a placeholder).
-      - name: Stamp signing config into ExportOptions.plist
-        working-directory: example/ios
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        shell: bash
-        run: |
-          PB=/usr/libexec/PlistBuddy
-          P=ExportOptions.plist
-          $PB -c "Set :teamID ${APPLE_TEAM_ID}" $P
-          $PB -c "Set :signingStyle manual" $P
-          $PB -c 'Add :provisioningProfiles dict' $P 2>/dev/null || true
-          $PB -c 'Add :provisioningProfiles:com.klaviyoreactnativesdkexample string "match AppStore com.klaviyoreactnativesdkexample"' $P
-          $PB -c 'Add :provisioningProfiles:com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension string "match AppStore com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension"' $P
-
-      # Manual signing using the match-installed identity + profiles. No
-      # -allowProvisioningUpdates / auth-key flags, so xcodebuild cannot reach
-      # App Store Connect to mint a certificate — it must use what match placed
-      # in the keychain and ~/Library/MobileDevice/Provisioning Profiles.
-      - name: Archive
-        working-directory: example/ios
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # RN build-phase scripts read this directly to wire codegen outputs.
-          RCT_NEW_ARCH_ENABLED: '1'
-          # Prevent Metro from starting a dev server.
-          CI: true
-        shell: bash
-        run: |
-          # DO NOT `rm -rf ./build` — pod install writes new-arch codegen
-          # headers (RCTAppDependencyProvider.h etc.) into ./build/generated/ios
-          # and xcodebuild reads them from there during archive.
-          rm -rf KlaviyoReactNativeSdkExample.xcarchive
-          # `-destination "generic/platform=iOS"` pins archive to iOS device.
-          # Without it, xcodebuild picks "My Mac" (Designed-for-iPad scheme
-          # on Apple Silicon advertises it as valid) and uses Development
-          # signing rules.
-          xcodebuild -workspace KlaviyoReactNativeSdkExample.xcworkspace \
-            -scheme KlaviyoReactNativeSdkExample \
-            -configuration Release \
-            -destination "generic/platform=iOS" \
-            archive -archivePath KlaviyoReactNativeSdkExample.xcarchive \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="$APPLE_TEAM_ID"
-
-      - name: Export IPA
-        working-directory: example/ios
-        shell: bash
-        run: |
-          xcodebuild -exportArchive \
-            -archivePath KlaviyoReactNativeSdkExample.xcarchive \
-            -exportOptionsPlist ExportOptions.plist \
-            -exportPath ./build
+          fastlane ios release_ipa
 
       # altool with the API key — no Apple ID / app-specific password / 2FA dance.
       - name: Upload to TestFlight

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -49,6 +49,12 @@ platform :ios do
       configuration: "Release",
       destination: "generic/platform=iOS",
       export_method: "app-store",
+      # Force the signing identity on the xcodebuild command line. The RN
+      # template sets CODE_SIGN_IDENTITY[sdk=iphoneos*] (legacy "iOS
+      # Distribution"), which overrides the per-target value set above for
+      # device builds. A command-line assignment outranks that SDK-conditional
+      # setting, so archive uses the "Apple Distribution" cert match installed.
+      codesigning_identity: "Apple Distribution",
       # pod install writes new-arch codegen headers into ./build/generated/ios;
       # gym must not wipe them.
       clean: false,

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -1,19 +1,66 @@
 default_platform(:ios)
 
+TEAM_ID = ENV["APPLE_TEAM_ID"]
+APP_ID = "com.klaviyoreactnativesdkexample"
+EXT_ID = "com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension"
+
 platform :ios do
-  # Installs the shared App Store distribution certificate + provisioning
-  # profiles from the klaviyo/mobile-certificates match repo into an ephemeral
-  # CI keychain. `readonly: true` means match only pulls from git and never
-  # contacts Apple — so it can never generate a new certificate. This replaces
-  # the previous cloud-managed signing (`xcodebuild -allowProvisioningUpdates`),
-  # which minted a fresh Apple Development cert on every run and exhausted the
-  # developer account's certificate cap.
+  # Build + sign the example app for TestFlight using fastlane match.
   #
-  # `setup_ci` creates the temporary keychain, unlocks it, and adds it to the
-  # search list so later archive/export steps can use the imported identity.
-  desc "Install App Store signing assets from match (read-only)"
-  lane :sync_signing do
+  # Why a single lane instead of raw xcodebuild steps: match installs the
+  # shared App Store distribution identity + profiles into an ephemeral
+  # keychain, but the app and its notification-service extension each need a
+  # *different* provisioning profile — which can't be expressed as global
+  # `xcodebuild` command-line build settings. Doing match + per-target signing
+  # config + build in one process lets gym apply the correct profile to each
+  # target and export a signed IPA.
+  #
+  # `readonly: true` => match only pulls from the mobile-certificates git repo
+  # and never contacts Apple, so it can never generate a certificate (the whole
+  # point: cloud-managed signing was exhausting the account's cert cap).
+  desc "Build + sign the example app IPA for TestFlight (match, read-only)"
+  lane :release_ipa do
     setup_ci
+
     match(type: "appstore", readonly: true)
+
+    # Pin each target to manual signing with its match profile + the shared
+    # distribution identity. Without this the project's default
+    # `CODE_SIGN_IDENTITY = "iPhone Developer"` would make archive look for a
+    # development cert that match never installs.
+    [
+      { targets: ["KlaviyoReactNativeSdkExample"], profile: "match AppStore #{APP_ID}" },
+      { targets: ["KlaviyoReactNativeSdkExampleExtension"], profile: "match AppStore #{EXT_ID}" },
+    ].each do |cfg|
+      update_code_signing_settings(
+        path: "ios/KlaviyoReactNativeSdkExample.xcodeproj",
+        use_automatic_signing: false,
+        team_id: TEAM_ID,
+        code_sign_identity: "Apple Distribution",
+        targets: cfg[:targets],
+        profile_name: cfg[:profile],
+        build_configurations: ["Release"]
+      )
+    end
+
+    build_app(
+      workspace: "ios/KlaviyoReactNativeSdkExample.xcworkspace",
+      scheme: "KlaviyoReactNativeSdkExample",
+      configuration: "Release",
+      destination: "generic/platform=iOS",
+      export_method: "app-store",
+      # pod install writes new-arch codegen headers into ./build/generated/ios;
+      # gym must not wipe them.
+      clean: false,
+      output_directory: "ios/build",
+      output_name: "KlaviyoReactNativeSdkExample.ipa",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          APP_ID => "match AppStore #{APP_ID}",
+          EXT_ID => "match AppStore #{EXT_ID}",
+        },
+      }
+    )
   end
 end

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -43,6 +43,16 @@ platform :ios do
       )
     end
 
+    # The RN template pins CODE_SIGN_IDENTITY[sdk=iphoneos*] to a legacy value
+    # that can override the command-line identity for device builds. Rewrite that
+    # SDK-conditional entry to the shared distribution identity so archive
+    # resolves to the "Apple Distribution" cert match installs.
+    pbxproj = File.expand_path("../ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj", __dir__)
+    content = File.read(pbxproj)
+    content.gsub!(/("CODE_SIGN_IDENTITY\[sdk=iphoneos\*\]" = )"[^"]*"/, '\1"Apple Distribution"')
+    File.write(pbxproj, content)
+    UI.message("Pinned CODE_SIGN_IDENTITY[sdk=iphoneos*] -> Apple Distribution")
+
     build_app(
       workspace: "ios/KlaviyoReactNativeSdkExample.xcworkspace",
       scheme: "KlaviyoReactNativeSdkExample",

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -24,6 +24,18 @@ platform :ios do
 
     match(type: "appstore", readonly: true)
 
+    # macOS 26's `security import` rejects empty-password .p12 files, and match
+    # imports keys with an empty password — so match's own key install silently
+    # fails on this runner (MAC verification failed). Bring the private key in
+    # ourselves from a password-protected .p12 (decoded from a secret by the
+    # workflow) into the same keychain match/setup_ci created.
+    import_certificate(
+      certificate_path: ENV.fetch("CERT_P12_PATH"),
+      certificate_password: ENV.fetch("P12_PASSWORD"),
+      keychain_name: ENV.fetch("MATCH_KEYCHAIN_NAME", "fastlane_tmp_keychain"),
+      keychain_password: ENV.fetch("MATCH_KEYCHAIN_PASSWORD", "")
+    )
+
     # Pin each target to manual signing with its match profile + the shared
     # distribution identity. Without this the project's default
     # `CODE_SIGN_IDENTITY = "iPhone Developer"` would make archive look for a

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -1,0 +1,19 @@
+default_platform(:ios)
+
+platform :ios do
+  # Installs the shared App Store distribution certificate + provisioning
+  # profiles from the klaviyo/mobile-certificates match repo into an ephemeral
+  # CI keychain. `readonly: true` means match only pulls from git and never
+  # contacts Apple — so it can never generate a new certificate. This replaces
+  # the previous cloud-managed signing (`xcodebuild -allowProvisioningUpdates`),
+  # which minted a fresh Apple Development cert on every run and exhausted the
+  # developer account's certificate cap.
+  #
+  # `setup_ci` creates the temporary keychain, unlocks it, and adds it to the
+  # search list so later archive/export steps can use the imported identity.
+  desc "Install App Store signing assets from match (read-only)"
+  lane :sync_signing do
+    setup_ci
+    match(type: "appstore", readonly: true)
+  end
+end

--- a/example/fastlane/Matchfile
+++ b/example/fastlane/Matchfile
@@ -1,0 +1,13 @@
+git_url("git@github.com:klaviyo/mobile-certificates.git")
+storage_mode("git")
+
+# App Store distribution assets for the example app + its notification-service
+# extension. The distribution certificate (JPSUA6BRFN) is shared via the
+# mobile-certificates repo and reused across the mobile SDK repos — CI never
+# generates a new one.
+type("appstore")
+
+app_identifier([
+  "com.klaviyoreactnativesdkexample",
+  "com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension",
+])


### PR DESCRIPTION
# Description

Fix the "maximum number of certificates" signing failures in the example app's TestFlight publish job by replacing cloud-managed signing with `fastlane match` (readonly), which reuses the shared distribution certificate instead of minting a new one every run.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable). <!-- iOS-only change; Android publish path untouched -->

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes. <!-- CI-only; no SDK/public API or runtime code changes -->
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - CI infrastructure fix; not tied to a released version.

## Changelog / Code Overview

**Problem.** The iOS `Publish to TestFlight` job signed via `xcodebuild -allowProvisioningUpdates` + an App Store Connect API key (cloud-managed automatic signing). On an ephemeral runner the keychain is empty every run, so Xcode minted a **new Apple Development certificate** on each publish. These accumulated until the account hit Apple's certificate cap, then archive failed with *"Your account has reached the maximum number of certificates."*

**Fix.** Switch to `fastlane match` in **readonly** mode, mirroring `klaviyo/ios-sdk-tester`:

- **`example/fastlane/Matchfile`** — points at `klaviyo/mobile-certificates`, `type("appstore")`, for `com.klaviyoreactnativesdkexample` and its `…Extension`.
- **`example/fastlane/Fastfile`** — `sync_signing` lane: `setup_ci` + `match(type: "appstore", readonly: true)`. Readonly pulls the shared distribution cert (`JPSUA6BRFN`) + profiles from git only; it never contacts Apple and never generates a certificate.
- **`.github/workflows/publish-example.yml`**:
  - New **"Sync signing assets (match, readonly)"** step (inline `ssh-agent` + read-only deploy key, then `fastlane ios sync_signing`).
  - **Archive/Export** switched to manual signing; removed `-allowProvisioningUpdates` and the `-authenticationKey*` flags (the flags that authorized cert creation).
  - `ExportOptions.plist` stamped to `signingStyle=manual` with per-target `provisioningProfiles` (match's `match AppStore <bundle-id>` names).
  - The `altool` upload step (ASC API key) is unchanged.

No SDK source, runtime, or public API changes — CI/signing only.

## Test Plan

> [!IMPORTANT]
> Draft — **blocked on prerequisites below**; do not merge until a bootstrap run + secrets are in place and the ios publish job is green.

**Prerequisites (owner action):**
1. **`MATCH_PASSWORD`** secret ← value from the "Fastlane Certificates Password" 1Password item (Eng Shared).
2. **`MATCH_DEPLOY_KEY`** secret ← private half of a **read-only SSH deploy key** added to `klaviyo/mobile-certificates`.
3. **One-time bootstrap** (needs Apple portal access + write to `mobile-certificates`) to generate the two App Store profiles against the existing cert:
   ```bash
   cd example
   fastlane match appstore --readonly false \
     --app_identifier "com.klaviyoreactnativesdkexample,com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension"
   ```

**Verification:** trigger the workflow (or add the `deploy-example-app:ios` label) and confirm the ios job archives, exports, and uploads to TestFlight with **no new certificate** created in the developer portal.

**Assumptions to confirm on the first CI run:**
- The `match` temp keychain (via `setup_ci`) remains available to the later Archive/Export steps (search list + keychain file persist across steps in the same job).
- Manual signing auto-matches each target to its installed `match AppStore <bundle-id>` profile without a per-target `PROVISIONING_PROFILE_SPECIFIER`.
- `fastlane` preinstalled on `macos-26` is a compatible version (else pin via a `gem install`/Gemfile step).

## Related Issues/Tickets

<!-- Add the Slack thread / Linear ticket for the certificate-cap incident -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release builds by using a consistent signing and provisioning process.
  * Added support for signing both the main app and its notification extension during distribution builds.
  * Updated the publishing workflow to produce and upload TestFlight-ready IPA files more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->