### PR TITLE
feat(example): add Subscriptions section to the example app [MAGE-913]

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,6 +20,7 @@ import { AnalyticsSection } from './sections/AnalyticsSection';
 import { FormsSection } from './sections/FormsSection';
 import { GeofencingSection } from './sections/GeofencingSection';
 import { PushSection } from './sections/PushSection';
+import { SubscriptionSection } from './sections/SubscriptionSection';
 
 // RN Installation Step: Source your public API key.
 // This example uses `react-native-dotenv` to inline `KLAVIYO_API_KEY` from
@@ -43,7 +44,12 @@ if (API_KEY.length === 0 || API_KEY === PLACEHOLDER_API_KEY) {
 // commented references in the iOS AppDelegate and Android MainApplication
 Klaviyo.initialize(API_KEY);
 
-type SectionKey = 'analytics' | 'forms' | 'geofencing' | 'push';
+type SectionKey =
+  | 'analytics'
+  | 'subscriptions'
+  | 'forms'
+  | 'geofencing'
+  | 'push';
 
 // SectionList data — each section corresponds to a feature domain. Each
 // section has a single item (the section key) whose content is rendered by
@@ -51,6 +57,7 @@ type SectionKey = 'analytics' | 'forms' | 'geofencing' | 'push';
 // Defined at module scope so the reference is stable across renders.
 const SECTIONS: { title: string; data: SectionKey[] }[] = [
   { title: 'Profile & Events', data: ['analytics'] },
+  { title: 'Subscriptions', data: ['subscriptions'] },
   { title: 'In-App Forms', data: ['forms'] },
   { title: 'Geofencing & Location', data: ['geofencing'] },
   { title: 'Push Notifications', data: ['push'] },
@@ -60,6 +67,8 @@ const renderSection = (sectionKey: SectionKey) => {
   switch (sectionKey) {
     case 'analytics':
       return <AnalyticsSection />;
+    case 'subscriptions':
+      return <SubscriptionSection />;
     case 'forms':
       return <FormsSection />;
     case 'geofencing':

--- a/example/src/Styles.ts
+++ b/example/src/Styles.ts
@@ -298,4 +298,27 @@ export const styles = StyleSheet.create({
   warningContainerWithBottomSpacing: {
     marginBottom: spacing.md,
   },
+  // Collapsible warning: tappable headline row + chevron. Mirrors the
+  // collapsible* styles so the affordance reads the same as the rest of the app,
+  // but keeps the warning palette.
+  warningHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  warningHeaderText: {
+    ...typography.body,
+    color: colors.warningText,
+    fontWeight: '600',
+    // Shrink rather than push the chevron off the row on narrow screens.
+    flexShrink: 1,
+    paddingRight: spacing.sm,
+  },
+  warningChevron: {
+    ...typography.body,
+    color: colors.warningText,
+  },
+  warningCollapsibleContent: {
+    marginTop: spacing.xs,
+  },
 });

--- a/example/src/Styles.ts
+++ b/example/src/Styles.ts
@@ -291,4 +291,11 @@ export const styles = StyleSheet.create({
     marginLeft: spacing.sm,
     marginTop: spacing.xs / 2,
   },
+  // Opt-in spacing for a warning that sits above other content. Matches
+  // profileFieldContainer's bottom margin so the vertical rhythm lines up.
+  // Not folded into warningContainer, which renders as the only child in
+  // PushSection and would gain a trailing gap.
+  warningContainerWithBottomSpacing: {
+    marginBottom: spacing.md,
+  },
 });

--- a/example/src/Styles.ts
+++ b/example/src/Styles.ts
@@ -253,6 +253,23 @@ export const styles = StyleSheet.create({
     fontWeight: '500',
   },
 
+  // Consent toggle styles
+  consentToggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.xs,
+  },
+  consentToggleLabel: {
+    ...typography.body,
+    color: colors.text,
+    flexShrink: 1,
+    paddingRight: spacing.sm,
+  },
+  consentToggleLabelDisabled: {
+    color: colors.secondaryText,
+  },
+
   // Warning message styles
   warningContainer: {
     backgroundColor: colors.warningBackground,

--- a/example/src/components/CollapsibleWarning.tsx
+++ b/example/src/components/CollapsibleWarning.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import {
+  LayoutAnimation,
+  Platform,
+  Text,
+  TouchableOpacity,
+  UIManager,
+  View,
+} from 'react-native';
+
+import { styles } from '../Styles';
+
+if (
+  Platform.OS === 'android' &&
+  UIManager.setLayoutAnimationEnabledExperimental
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+interface CollapsibleWarningProps {
+  title: string;
+  initiallyExpanded?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * A warning callout whose detail hides behind a chevron, collapsed by default.
+ *
+ * Keeps a one-off caveat from dominating a section: the headline stays visible,
+ * the explanation is one tap away. Uses the same chevron and easeInEaseOut
+ * animation as {@link Collapsible} so the affordance is familiar, but keeps the
+ * warning palette rather than the neutral field-group styling.
+ *
+ * Carries its own bottom spacing, since a warning of this shape always sits
+ * above other content.
+ */
+export const CollapsibleWarning: React.FC<CollapsibleWarningProps> = ({
+  title,
+  initiallyExpanded = false,
+  children,
+}) => {
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+
+  const toggle = () => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpanded((prev) => !prev);
+  };
+
+  return (
+    <View
+      style={[
+        styles.warningContainer,
+        styles.warningContainerWithBottomSpacing,
+      ]}
+    >
+      <TouchableOpacity
+        style={styles.warningHeaderRow}
+        onPress={toggle}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={title}
+        accessibilityState={{ expanded }}
+        accessibilityHint={expanded ? 'Hides the details' : 'Shows the details'}
+      >
+        <Text style={styles.warningHeaderText}>{title}</Text>
+        <Text style={styles.warningChevron}>{expanded ? '▾' : '▸'}</Text>
+      </TouchableOpacity>
+      {expanded && (
+        <View style={styles.warningCollapsibleContent}>{children}</View>
+      )}
+    </View>
+  );
+};

--- a/example/src/components/CollapsibleWarning.tsx
+++ b/example/src/components/CollapsibleWarning.tsx
@@ -57,6 +57,11 @@ export const CollapsibleWarning: React.FC<CollapsibleWarningProps> = ({
         style={styles.warningHeaderRow}
         onPress={toggle}
         activeOpacity={0.7}
+        // The row is a single line of text, so extend the touch target to ~44pt
+        // via hitSlop rather than minHeight: it reaches into the container's
+        // padding, which is dead space anyway, without making the collapsed
+        // warning taller — the point of collapsing it was to take up less room.
+        hitSlop={{ top: 12, bottom: 12, left: 0, right: 0 }}
         accessibilityRole="button"
         accessibilityLabel={title}
         accessibilityState={{ expanded }}

--- a/example/src/components/ConsentToggle.tsx
+++ b/example/src/components/ConsentToggle.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Switch, Text, View } from 'react-native';
+
+import { styles } from '../Styles';
+import { colors } from '../theme';
+
+interface ConsentToggleProps {
+  label: string;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+  disabled?: boolean;
+}
+
+/**
+ * A labelled switch for one independently-selectable consent sub-type.
+ *
+ * ToggleButtons is deliberately not reused here: it models a mutually exclusive
+ * either/or choice, whereas consent sub-types can each be granted on their own.
+ */
+export const ConsentToggle: React.FC<ConsentToggleProps> = ({
+  label,
+  value,
+  onValueChange,
+  disabled = false,
+}) => (
+  <View style={styles.consentToggleRow}>
+    <Text
+      style={[
+        styles.consentToggleLabel,
+        disabled && styles.consentToggleLabelDisabled,
+      ]}
+    >
+      {label}
+    </Text>
+    <Switch
+      value={value}
+      onValueChange={onValueChange}
+      disabled={disabled}
+      trackColor={{ false: colors.border, true: colors.primary }}
+      accessibilityLabel={label}
+    />
+  </View>
+);

--- a/example/src/hooks/useSubscription.ts
+++ b/example/src/hooks/useSubscription.ts
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { Alert } from 'react-native';
+import {
+  Klaviyo,
+  EmailConsent,
+  MessagingConsent,
+  allAvailableMarketing,
+  type SubscriptionChannels,
+} from 'klaviyo-react-native-sdk';
+
+export function useSubscription() {
+  // Target list
+  const [listId, setListId] = useState('');
+  const [customSource, setCustomSource] = useState('');
+
+  // Broad grant — when on, the per-channel consent below is ignored
+  const [allMarketing, setAllMarketing] = useState(false);
+
+  // Per-channel consent
+  const [emailMarketing, setEmailMarketing] = useState(false);
+  const [emailOpenTracking, setEmailOpenTracking] = useState(false);
+  const [smsMarketing, setSmsMarketing] = useState(false);
+  const [smsTransactional, setSmsTransactional] = useState(false);
+  const [whatsappMarketing, setWhatsappMarketing] = useState(false);
+  const [whatsappTransactional, setWhatsappTransactional] = useState(false);
+
+  // Builds the channels object, omitting any channel with nothing selected so we
+  // never send an empty consent array the native SDK would just warn about.
+  const buildChannels = (): SubscriptionChannels => {
+    const email: EmailConsent[] = [];
+    if (emailMarketing) email.push(EmailConsent.Marketing);
+    if (emailOpenTracking) email.push(EmailConsent.OpenTracking);
+
+    const sms: MessagingConsent[] = [];
+    if (smsMarketing) sms.push(MessagingConsent.Marketing);
+    if (smsTransactional) sms.push(MessagingConsent.Transactional);
+
+    const whatsapp: MessagingConsent[] = [];
+    if (whatsappMarketing) whatsapp.push(MessagingConsent.Marketing);
+    if (whatsappTransactional) whatsapp.push(MessagingConsent.Transactional);
+
+    return {
+      ...(email.length > 0 && { email }),
+      ...(sms.length > 0 && { sms }),
+      ...(whatsapp.length > 0 && { whatsapp }),
+    };
+  };
+
+  const handleCreateSubscription = () => {
+    const trimmedListId = listId.trim();
+    if (!trimmedListId) {
+      Alert.alert(
+        'List ID required',
+        'Enter the ID of the Klaviyo list to subscribe this profile to.'
+      );
+      return;
+    }
+
+    // An empty custom source would be sent as an empty $source label, so drop it.
+    const source = customSource.trim() || undefined;
+
+    if (allMarketing) {
+      console.log(
+        `[useSubscription] subscribing to ${trimmedListId} → all available marketing`
+      );
+      Klaviyo.createSubscription(allAvailableMarketing(trimmedListId, source));
+      return;
+    }
+
+    const channels = buildChannels();
+    if (Object.keys(channels).length === 0) {
+      Alert.alert(
+        'No consent selected',
+        'Choose at least one channel consent type, or turn on "All available marketing".'
+      );
+      return;
+    }
+
+    console.log(
+      `[useSubscription] subscribing to ${trimmedListId} → ${JSON.stringify(channels)}`
+    );
+    Klaviyo.createSubscription({
+      listId: trimmedListId,
+      channels,
+      customSource: source,
+    });
+  };
+
+  return {
+    // Target list
+    listId,
+    setListId,
+    customSource,
+    setCustomSource,
+
+    // Broad grant
+    allMarketing,
+    setAllMarketing,
+
+    // Per-channel consent
+    emailMarketing,
+    setEmailMarketing,
+    emailOpenTracking,
+    setEmailOpenTracking,
+    smsMarketing,
+    setSmsMarketing,
+    smsTransactional,
+    setSmsTransactional,
+    whatsappMarketing,
+    setWhatsappMarketing,
+    whatsappTransactional,
+    setWhatsappTransactional,
+
+    // Handlers
+    handleCreateSubscription,
+  };
+}

--- a/example/src/sections/SubscriptionSection.tsx
+++ b/example/src/sections/SubscriptionSection.tsx
@@ -12,7 +12,12 @@ export function SubscriptionSection() {
 
   return (
     <View style={styles.section}>
-      <View style={styles.warningContainer}>
+      <View
+        style={[
+          styles.warningContainer,
+          styles.warningContainerWithBottomSpacing,
+        ]}
+      >
         <Text style={styles.warningText}>
           Set an email or phone number before subscribing.
         </Text>

--- a/example/src/sections/SubscriptionSection.tsx
+++ b/example/src/sections/SubscriptionSection.tsx
@@ -1,0 +1,92 @@
+import { Text, View } from 'react-native';
+
+import { useSubscription } from '../hooks/useSubscription';
+import { styles } from '../Styles';
+import { ActionButton } from '../components/ActionButton';
+import { Collapsible } from '../components/Collapsible';
+import { ConsentToggle } from '../components/ConsentToggle';
+import { ProfileTextField } from '../components/ProfileTextField';
+
+export function SubscriptionSection() {
+  const subscription = useSubscription();
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.warningContainer}>
+        <Text style={styles.warningText}>
+          Set an email or phone number before subscribing.
+        </Text>
+        <Text style={styles.warningSubtext}>
+          The native SDK drops a subscription whose channel has no matching
+          identifier on the profile. Use Profile &amp; Events above to set one.
+        </Text>
+      </View>
+      <ProfileTextField
+        label="List ID"
+        value={subscription.listId}
+        onChangeText={subscription.setListId}
+        placeholder="ABC123"
+      />
+      <ProfileTextField
+        label="Custom Source (optional)"
+        value={subscription.customSource}
+        onChangeText={subscription.setCustomSource}
+        placeholder="Checkout screen"
+      />
+      <ConsentToggle
+        label="All available marketing"
+        value={subscription.allMarketing}
+        onValueChange={subscription.setAllMarketing}
+      />
+      {/*
+        Requesting all-available-marketing lets the server pick the channels, so the
+        per-channel picker below is disabled rather than hidden — leaving it visible
+        makes it clear which choices are being superseded.
+      */}
+      <Collapsible title="Channel Consent">
+        <ConsentToggle
+          label="Email — Marketing"
+          value={subscription.emailMarketing}
+          onValueChange={subscription.setEmailMarketing}
+          disabled={subscription.allMarketing}
+        />
+        <ConsentToggle
+          label="Email — Open Tracking"
+          value={subscription.emailOpenTracking}
+          onValueChange={subscription.setEmailOpenTracking}
+          disabled={subscription.allMarketing}
+        />
+        <ConsentToggle
+          label="SMS — Marketing"
+          value={subscription.smsMarketing}
+          onValueChange={subscription.setSmsMarketing}
+          disabled={subscription.allMarketing}
+        />
+        <ConsentToggle
+          label="SMS — Transactional"
+          value={subscription.smsTransactional}
+          onValueChange={subscription.setSmsTransactional}
+          disabled={subscription.allMarketing}
+        />
+        <ConsentToggle
+          label="WhatsApp — Marketing"
+          value={subscription.whatsappMarketing}
+          onValueChange={subscription.setWhatsappMarketing}
+          disabled={subscription.allMarketing}
+        />
+        <ConsentToggle
+          label="WhatsApp — Transactional"
+          value={subscription.whatsappTransactional}
+          onValueChange={subscription.setWhatsappTransactional}
+          disabled={subscription.allMarketing}
+        />
+      </Collapsible>
+      <ActionButton
+        title="Subscribe"
+        onPress={subscription.handleCreateSubscription}
+        disabled={!subscription.listId.trim()}
+        withTopSpacing
+      />
+    </View>
+  );
+}

--- a/example/src/sections/SubscriptionSection.tsx
+++ b/example/src/sections/SubscriptionSection.tsx
@@ -4,6 +4,7 @@ import { useSubscription } from '../hooks/useSubscription';
 import { styles } from '../Styles';
 import { ActionButton } from '../components/ActionButton';
 import { Collapsible } from '../components/Collapsible';
+import { CollapsibleWarning } from '../components/CollapsibleWarning';
 import { ConsentToggle } from '../components/ConsentToggle';
 import { ProfileTextField } from '../components/ProfileTextField';
 
@@ -12,20 +13,12 @@ export function SubscriptionSection() {
 
   return (
     <View style={styles.section}>
-      <View
-        style={[
-          styles.warningContainer,
-          styles.warningContainerWithBottomSpacing,
-        ]}
-      >
-        <Text style={styles.warningText}>
-          Set an email or phone number before subscribing.
-        </Text>
+      <CollapsibleWarning title="Set an email or phone number first">
         <Text style={styles.warningSubtext}>
           The native SDK drops a subscription whose channel has no matching
           identifier on the profile. Use Profile &amp; Events above to set one.
         </Text>
-      </View>
+      </CollapsibleWarning>
       <ProfileTextField
         label="List ID"
         value={subscription.listId}


### PR DESCRIPTION
# Description

Adds a **Subscriptions** section to the in-repo example app, demonstrating `Klaviyo.createSubscription` from MAGE-856.

> **Stacked PR.** Based on `asb/mage-856-bridge-subscription-method` so this diff shows only its own 5 files. GitHub will auto-retarget it to `feat/subscription-methods-sdk` when #396 merges and its branch is deleted.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - Verified on a **physical device** by @Atharva8168: the Subscriptions section renders correctly, the warning is collapsed to its headline by default and expands/collapses on tap, and the spacing above the List ID field is right. Screenshots to follow separately.
- [ ] I have added sufficient unit/integration tests of my changes.
  - The example app has **no test infrastructure** — no `test` script, no jest/RTL dependency, zero test files, and no `testID` convention anywhere in `example/src`. Adding either would mean inventing a convention and touching every shared component's prop interface, so this follows the existing sections in having none.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - Pure React Native, no platform-conditional code.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - Example-app only — no SDK surface change. The public API ships in #396.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

Follows the established section pattern, so `App.tsx` keeps holding no feature state and each section owns its own hook.

- **`example/src/hooks/useSubscription.ts`** — list ID, custom source, per-channel consent, and the all-available-marketing flag. `buildChannels()` omits any channel with nothing selected rather than sending an empty consent array the native SDK would only warn about. Guards an empty list ID and an empty consent selection with `Alert.alert`.
- **`example/src/sections/SubscriptionSection.tsx`** — list ID + custom source fields, the broad-grant switch, and a `Collapsible` per-channel picker (email / SMS / WhatsApp). Leads with the set-an-identifier-first caveat via the existing `warningContainer` styles, since the native SDK drops a subscription whose channel has no matching identifier.
- **`example/src/components/ConsentToggle.tsx`** — a labelled `Switch`. `ToggleButtons` was deliberately **not** reused: it models a mutually exclusive either/or, whereas consent sub-types are each independently grantable.
- **`example/src/Styles.ts`** — three keys for the new toggle row; no per-file StyleSheet, matching the single-shared-`styles` convention.
- **`example/src/App.tsx`** — new `'subscriptions'` `SectionKey`, `SECTIONS` entry, and `renderSection` case.

Turning on all-available-marketing **disables** the per-channel picker rather than hiding it, so it's visible which choices are being superseded.

### Deviation from the ticket, flagged for your call

MAGE-913 specifies a listId field plus a Subscribe button hardcoded to email/marketing with "no channel/type UI". This builds the **full per-channel picker** instead, for parity with what the Flutter example app shipped in klaviyo/klaviyo-flutter-sdk#118. Straightforward to reduce to the literal scope if preferred.

Separately, the ticket's premise that scaffolding must be built from scratch is stale — it references `example/src/AppViewInterface.ts` and claims there is no `TextInput`/`useState`. That file no longer exists and the example app already provides `ProfileTextField`, `ToggleButtons`, `Collapsible`, and extensive `useState`. Noted on the ticket.

## Test Plan

Automated: `yarn typecheck`, `yarn lint`, `yarn test` all green (66 jest tests, unchanged by this PR).

Manual, on **both** platforms:

1. `yarn example android` / `yarn example ios` (requires `example/.env` with `KLAVIYO_API_KEY` — `App.tsx` throws at module scope without it).
2. Profile & Events → set an email.
3. Subscriptions → enter a real list ID, expand **Channel Consent**, enable Email — Marketing, tap **Subscribe**.
4. Confirm the profile appears on that list in-account.
5. Enter a custom source and re-subscribe; confirm `$source` reflects it.
6. Toggle **All available marketing** — confirm the per-channel switches grey out — and subscribe.
7. Negative: tap Subscribe with a list ID but no consent selected → "No consent selected" alert, nothing sent.
8. Negative: subscribe with no email/phone on the profile → native logs a warning and drops the request.

⚠️ On Android the SDK only transmits over an OS-**validated** network. An emulator behind a VPN/proxy/Private DNS or on a stale snapshot queues everything with "Send prevented while network unavailable". Use a physical device or a cold boot.

## Related Issues/Tickets

- Closes [MAGE-913](https://linear.app/klaviyo/issue/MAGE-913)
- Depends on [MAGE-856](https://linear.app/klaviyo/issue/MAGE-856) — #396, the bridge this consumes
- Flutter equivalent: [MAGE-912](https://linear.app/klaviyo/issue/MAGE-912) / klaviyo/klaviyo-flutter-sdk#118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Subscriptions section to the app.
  * Added a subscription form for list IDs, optional sources, and marketing consent.
  * Added separate consent controls for email, SMS, and WhatsApp channels.
  * Added support for subscribing to all available marketing channels at once.
  * Added validation, accessible toggle labels, disabled states, and helpful profile warnings.
  * Added collapsible warning details with animated expand and collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
