### PR TITLE
ci: fail the release when a development SDK pin would ship

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -23,6 +23,7 @@ jobs:
           set -uo pipefail
           fail=0
           podspec=klaviyo-react-native-sdk.podspec
+          podfile=example/ios/Podfile
 
           # Fully anchored, and SNAPSHOT rejected separately: a prerelease suffix is legitimate
           # (2.2.0-alpha.1 is a real tag), but '4.5.0-SNAPSHOT' is a JitPack build that
@@ -48,6 +49,20 @@ jobs:
           if [ -n "$unpinned" ]; then
             echo "::error file=$podspec::Every Klaviyo pod must declare a published version. Offending lines:"
             echo "$unpinned"
+            fail=1
+          fi
+
+          # The example app's Podfile never reaches integrators, so this one is not about what
+          # ships: a release tag would leave the example resolving pods from a branch that gets
+          # deleted once it merges, and `pod install` on that tag then fails for good. Good shape
+          # asserted rather than grepping for :git / :branch, because the source can sit on another
+          # line entirely via a splatted hash (`pod 'KlaviyoCore', **klaviyo_swift_sdk`). A bare
+          # `pod 'KlaviyoSwiftExtension'` or a quoted version is what a released tree looks like.
+          dev_pods=$(grep -nE "^[[:space:]]*pod[[:space:]]+'Klaviyo[A-Za-z]*'" "$podfile" \
+            | grep -vE "^[0-9]+:[[:space:]]*pod[[:space:]]+'Klaviyo[A-Za-z]*'([[:space:]]*,[[:space:]]*'[^']+')?[[:space:]]*(#.*)?$" || true)
+          if [ -n "$dev_pods" ]; then
+            echo "::error file=$podfile::The example app must not pin Klaviyo pods to a branch, commit, or local path. Restore them before releasing. Offending lines:"
+            echo "$dev_pods"
             fail=1
           fi
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -14,6 +14,44 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # A release must never ship a development pin. configure-sdk.sh rewrites these files to point
+      # at a branch, commit, or local path while developing against an unreleased native SDK, and
+      # restoring them is easy to forget. Checked here so one gate covers both platforms;
+      # android/build.gradle carries an equivalent guard for local release builds.
+      - name: Verify no development SDK pins
+        run: |
+          set -uo pipefail
+          fail=0
+          podspec=klaviyo-react-native-sdk.podspec
+
+          # Fully anchored, and SNAPSHOT rejected separately: a prerelease suffix is legitimate
+          # (2.2.0-alpha.1 is a real tag), but '4.5.0-SNAPSHOT' is a JitPack build that
+          # configure-sdk.sh writes through verbatim because it already looks like a semver.
+          # android/gradle.properties ships in the npm package, so this must not leak.
+          # tr strips a stray CR so a CRLF checkout doesn't trip a false rejection; the SNAPSHOT
+          # test is case-insensitive because the prerelease pattern above would otherwise accept
+          # a hand-written '4.5.0-snapshot' as a legitimate version.
+          android_version=$(sed -n 's/^KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=//p' android/gradle.properties | tr -d '\r')
+          android_upper=$(printf '%s' "$android_version" | tr '[:lower:]' '[:upper:]')
+          if [[ ! "$android_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] || [[ "$android_upper" == *SNAPSHOT* ]]; then
+            echo "::error file=android/gradle.properties::Android SDK pin '$android_version' is not a published version. Restore it before releasing."
+            fail=1
+          fi
+
+          # configure-sdk.sh comments out the version constraint as: s.dependency "KlaviyoSwift" ##, "5.3.1"
+          if grep -qE '^\s*s\.dependency\s+"Klaviyo[A-Za-z]*"\s*##' "$podspec"; then
+            echo "::error file=$podspec::Klaviyo pod version constraints are commented out (configure-sdk.sh local mode). Restore them before releasing."
+            fail=1
+          fi
+
+          # Scoped to dependency lines: s.source legitimately uses :git for this repo itself.
+          if grep -E '^\s*s\.dependency' "$podspec" | grep -qE ':git|:branch|:commit|:path'; then
+            echo "::error file=$podspec::A Klaviyo pod resolves from git or a local path instead of a published version. Restore it before releasing."
+            fail=1
+          fi
+
+          exit $fail
+
       - name: Setup
         uses: ./.github/actions/setup
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -38,15 +38,16 @@ jobs:
             fail=1
           fi
 
-          # configure-sdk.sh comments out the version constraint as: s.dependency "KlaviyoSwift" ##, "5.3.1"
-          if grep -qE '^\s*s\.dependency\s+"Klaviyo[A-Za-z]*"\s*##' "$podspec"; then
-            echo "::error file=$podspec::Klaviyo pod version constraints are commented out (configure-sdk.sh local mode). Restore them before releasing."
-            fail=1
-          fi
-
-          # Scoped to dependency lines: s.source legitimately uses :git for this repo itself.
-          if grep -E '^\s*s\.dependency' "$podspec" | grep -qE ':git|:branch|:commit|:path'; then
-            echo "::error file=$podspec::A Klaviyo pod resolves from git or a local path instead of a published version. Restore it before releasing."
+          # Assert the good shape rather than blacklisting the bad ones. bump-version.sh documents
+          # three forms it normalizes — `s.dependency "Name"`, `s.dependency "Name" ##, "old"` and
+          # `s.dependency "Name", "old"` — and the first two both resolve unconstrained, since ##
+          # opens a Ruby comment. Requiring a quoted version covers those plus :git / :path sources
+          # and anything else. Scoped to Klaviyo pods, so a bare `s.dependency "React-Core"` is fine.
+          unpinned=$(grep -nE '^[[:space:]]*s\.dependency[[:space:]]+"Klaviyo[A-Za-z]*"' "$podspec" \
+            | grep -vE '^[0-9]+:[[:space:]]*s\.dependency[[:space:]]+"Klaviyo[A-Za-z]*"[[:space:]]*,[[:space:]]*"[^"]+"[[:space:]]*(#.*)?$' || true)
+          if [ -n "$unpinned" ]; then
+            echo "::error file=$podspec::Every Klaviyo pod must declare a published version. Offending lines:"
+            echo "$unpinned"
             fail=1
           fi
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,6 +89,28 @@ repositories {
 }
 
 def klaviyoAndroidSdkVersion = getExtOrDefault("klaviyoAndroidSdkVersion")
+
+// A development pin is a moving target and must never ship. configure-sdk.sh sets
+// klaviyoAndroidSdkVersion to a JitPack snapshot ("rel~4.5.0-SNAPSHOT"), a commit hash, or a local
+// path while developing against an unreleased Android SDK; this fails the release assembly rather
+// than relying on someone remembering to restore it. A prerelease suffix is allowed because
+// "2.2.0-alpha.1" is a real published version, but SNAPSHOT never is.
+// publish-sdk.yml applies the equivalent check at the release gate, covering iOS too.
+tasks.matching { it.name.toLowerCase().contains("release") }.configureEach {
+  doFirst {
+    // Case-insensitive: the prerelease group above would otherwise accept "4.5.0-snapshot".
+    def pin = klaviyoAndroidSdkVersion?.trim() ?: ""
+    def published = pin ==~ /^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$/
+    if (!published || pin.toUpperCase().contains("SNAPSHOT")) {
+      throw new GradleException(
+          "Refusing to build a release against the unpublished klaviyo-android-sdk pin " +
+          "'${klaviyoAndroidSdkVersion}'. Set KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion in " +
+          "android/gradle.properties to a published version before releasing."
+      )
+    }
+  }
+}
+
 def kotlin_version = getExtOrDefault("kotlinVersion")
 def localProperties = new Properties()
 if (rootProject.file("local.properties").canRead()) {


### PR DESCRIPTION
# Description

Fails a release build when a development SDK pin would ship. Split out of #396 at review request — it protects every release from this repo, not just the subscriptions work, and shouldn't be gated on that PR's rollup.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — CI/release tooling only, no runtime code.
- [x] I have added sufficient unit/integration tests of my changes.
  - No test harness exists for workflow YAML, so the predicate was exercised directly instead — full matrix below, with the gradle side driven through a real `preReleaseBuild`.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - Deliberately covers both: the Android pin and the iOS podspec.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

`configure-sdk.sh` rewrites the Android pin and the podspec to point at a branch, commit, or local path while developing against an unreleased native SDK. Restoring them before release is currently down to someone remembering.

**`.github/workflows/publish-sdk.yml`** — a `Verify no development SDK pins` step, placed before `Setup` so it fails fast. It rejects a release when:

- the Android pin in `android/gradle.properties` is not a published version — this file **ships in the npm package** (`android` is in `files`)
- the podspec's Klaviyo version constraints are commented out — the `s.dependency "KlaviyoSwift" ##, "5.3.1"` form `configure-sdk.sh` writes in local mode
- any Klaviyo `s.dependency` resolves from `:git` / `:branch` / `:commit` / `:path`
- any Klaviyo pod in `example/ios/Podfile` resolves from anything but a published version — `:git` / `:branch` / `:commit` / `:path`, or a splatted hash that puts the source on its own line (`pod 'KlaviyoCore', **klaviyo_swift_sdk`, the form #396 uses). This file does **not** ship, so the concern is different: a release tag would leave the example app resolving pods from a branch that gets deleted once it merges, and `pod install` on that tag then fails permanently for anyone who clones it to try the example. Raised in review of #396 — Evan's ask was a gate covering both platforms, and this was the one committed file `configure-sdk.sh` rewrites that the gate did not look at.

The git check is scoped to `s.dependency` lines, because the podspec's own `s.source` legitimately uses `:git` for this repo and a blanket grep false-positives on it.

**`android/build.gradle`** — the equivalent check on release tasks, so a bad pin fails during a local release build long before anyone reaches the publish workflow.

A prerelease suffix is accepted, since `2.2.0-alpha.1` and `1.2.0-alpha.1` are real published tags. `SNAPSHOT` never is, matched case-insensitively — without that, the prerelease pattern would happily accept a hand-written `4.5.0-snapshot`.

### ⚠️ This immediately flags the current state of `rel/2.5.0`

Not a hypothetical. `rel/2.5.0`'s podspec today reads:

```ruby
s.dependency "KlaviyoSwift" ##, "5.4.0"
s.dependency "KlaviyoLocation" ##, "5.4.0"
s.dependency "KlaviyoForms" ##, "5.4.0"
```

That came from #379 (`8ac7109`) and is **deliberate and ticketed** — the Podfile alongside it carries a clear `TODO(MAGE-874)` to restore the pins once KlaviyoSwift 5.4.0 ships. So this is not a bug report; it is exactly the situation the guard exists for.

But as committed, a 2.5.0 release would publish a podspec with **no version constraint** on those three pods, letting integrators resolve any KlaviyoSwift. With this guard in place, that release fails instead, and the MAGE-874 TODO becomes enforced rather than remembered.

`master` is unaffected — it still reads `s.dependency "KlaviyoSwift", "5.3.1"`.

## Test Plan

The predicate was exercised directly, since workflow YAML has no test harness.

**Accepted:** `4.5.0`, `4.4.1`, `2.2.0-alpha.1`, `4.2.0-rc.1`
**Rejected:** `4.5.0-SNAPSHOT`, `4.5.0-snapshot`, `4.5.0-Snapshot`, `rel~4.5.0-SNAPSHOT`, `rel/4.5.0`, a commit hash, `../klaviyo-android-sdk`, empty, `4.5`

The `android/build.gradle` guard was driven through a real `./gradlew :klaviyo-react-native-sdk:preReleaseBuild`: rejects with a clear message on a bad pin, passes on `4.4.0` and `2.2.0-alpha.1`, and debug builds are unaffected.

The podspec checks were run against a clean tree (passes) and all three dirty states (each fails with a targeted `::error file=` annotation), plus against `rel/2.5.0` as-is — where it correctly flags the commented-out constraints described above.

The Podfile check was driven the same way, by extracting the step from the YAML and running it against real trees: `master`'s Podfile **passes**; `rel/2.5.0` and #396 each **fail with all five offending lines listed** (including #396's four splatted-hash lines, which a `:git`/`:branch` grep would miss); a synthetic `:path` and `:commit` are rejected; and `pod 'KlaviyoSwiftExtension'`, `pod 'KlaviyoSwift', '5.4.0'` and a commented-out pod line all pass. Running the full step against this branch's own tree reports the podspec and Podfile failures together and exits 1.

## Related Issues/Tickets

- Split out of #396 ([MAGE-856](https://linear.app/klaviyo/issue/MAGE-856)) per review
- Originally suggested by @evan-masseau on #396
- Surfaces the [MAGE-874](https://linear.app/klaviyo/issue/MAGE-874) podspec TODO on `rel/2.5.0`

