### PR TITLE
fix(android): use locale-independent uppercase for consent enum mapping

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -35,6 +35,7 @@ import com.klaviyo.location.LocationManager
 import com.klaviyo.location.registerGeofencing
 import com.klaviyo.location.unregisterGeofencing
 import java.io.Serializable
+import java.util.Locale
 import kotlin.reflect.KVisibility
 import kotlin.time.Duration.Companion.seconds
 
@@ -433,7 +434,7 @@ class KlaviyoReactNativeSdkModule(
           null
         }
       }?.mapNotNull { rawValue ->
-        runCatching { valueOf(rawValue.uppercase()) }.getOrElse {
+        runCatching { valueOf(rawValue.uppercase(Locale.ROOT)) }.getOrElse {
           Registry.log.warning(
             "Klaviyo React Native SDK: Ignoring unrecognized $key consent type '$rawValue'",
           )


### PR DESCRIPTION
# Description

Fixes a Bugbot finding from #403: Android's consent-enum mapping used locale-sensitive `uppercase()`, so on a Turkish-locale device `createSubscription` could silently drop consent channels that iOS applies correctly.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

_No native unit test harness exists for this bridge module today (no Android test source set in this repo), so there's nothing to add tests to — this mirrors existing coverage for the surrounding function._

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

This targets `rel/2.5.0` directly since it fixes a bug introduced by unreleased code already on that branch (subscription methods added in #400).

## Changelog / Code Overview

`ReadableMap.parseConsentSet` in `KlaviyoReactNativeSdkModule.kt` mapped JS consent strings (e.g. `"marketing"`) onto native enum names via `rawValue.uppercase()`. `String.uppercase()` with no locale argument uses the JVM default/device locale. Under Turkish (`tr`), lowercase `i` uppercases to `İ` (dotted capital I) rather than `I`, so `"marketing".uppercase()` produces `"MARKETİNG"`, which no longer matches the enum constant `MARKETING`. `Enum.valueOf` throws, the existing `runCatching` swallows it and logs a warning, and the channel is dropped — so a user on a Turkish-locale device calling `createSubscription({ channels: { email: ['marketing'] } })` gets no email consent applied on Android, while iOS (which switches on literal string values, not locale-aware casing) applies the same payload correctly.

Fix: use `rawValue.uppercase(Locale.ROOT)` so the mapping is locale-independent, matching how enum name mapping is generally expected to behave.

## Test Plan

Manual repro (documented, not automated — no native test harness in this module):
1. Set an Android emulator/device's locale to Turkish (`tr-TR`).
2. Call `Klaviyo.createSubscription({ listId, channels: { email: ['marketing'] } })`.
3. Before the fix: warning log "Ignoring unrecognized email consent type 'marketing'", channel dropped.
4. After the fix: consent applied correctly, matching non-Turkish-locale and iOS behavior.

Verified `ktlint` passes on the changed file with no new violations.

## Related Issues/Tickets

- [MAGE-1083](https://linear.app/klaviyo/issue/MAGE-1083)
- Bugbot finding: https://github.com/klaviyo/klaviyo-react-native-sdk/pull/403#discussion_r3784724653
