### PR TITLE
fix: warn when a subscription channel value is present but the wrong type

### DIFF
--- a/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
+++ b/android/src/main/java/com/klaviyoreactnativesdk/KlaviyoReactNativeSdkModule.kt
@@ -417,13 +417,25 @@ class KlaviyoReactNativeSdkModule(
    * unrecognized value is warned about and skipped rather than failing the whole request: skipping
    * only ever narrows the consent granted, and it keeps a newer JS layer from breaking against an
    * older native SDK. A non-string entry is skipped the same way. iOS drops both the same way.
+   *
+   * A present-but-wrong-type value (e.g. a string instead of an array) is also treated as an
+   * omitted channel, but unlike a genuinely absent key, it's warned about first: silently applying
+   * the same behavior as "not specified" could otherwise mask a caller mistake.
    */
   private fun <T : Enum<T>> ReadableMap.parseConsentSet(
     key: String,
     valueOf: (String) -> T,
-  ): Set<T>? =
-    takeIf { it.hasKey(key) && it.getType(key) == ReadableType.Array }
-      ?.getArray(key)
+  ): Set<T>? {
+    if (!hasKey(key)) return null
+
+    if (getType(key) != ReadableType.Array) {
+      Registry.log.warning(
+        "Klaviyo React Native SDK: Ignoring non-array $key consent value",
+      )
+      return null
+    }
+
+    return getArray(key)
       ?.toArrayList()
       ?.mapNotNull { entry ->
         entry as? String ?: run {
@@ -440,6 +452,7 @@ class KlaviyoReactNativeSdkModule(
           null
         }
       }?.toSet()
+  }
 
   @ReactMethod
   fun registerFormLifecycleHandler() {

--- a/ios/KlaviyoBridge.swift
+++ b/ios/KlaviyoBridge.swift
@@ -341,12 +341,21 @@ public class KlaviyoBridge: NSObject {
     /// that channel is left untouched. An empty array stays empty, so the native SDK's own
     /// validation reports it rather than this bridge silently dropping the channel.
     ///
+    /// A present-but-wrong-type value (e.g. a string instead of an array) is also treated as an
+    /// omitted channel, but unlike a genuinely absent key, it's warned about first: silently
+    /// applying the same behavior as "not specified" could otherwise mask a caller mistake.
+    ///
     /// A non-string entry is skipped individually rather than discarding the whole channel, so a
     /// partially malformed array still applies the consent values it does carry. Only a direct
     /// native caller can reach this — the TypeScript layer rejects the input first. Android drops
     /// entries the same way.
     private static func consentValues(from channels: [String: AnyObject], key: String) -> [String]? {
-        guard let rawValues = channels[key] as? [AnyObject] else { return nil }
+        guard let rawValue = channels[key] else { return nil }
+
+        guard let rawValues = rawValue as? [AnyObject] else {
+            NSLog("[Klaviyo] Warning: Ignoring non-array \(key) consent value")
+            return nil
+        }
 
         return rawValues.compactMap { rawValue in
             guard let stringValue = rawValue as? String else {


### PR DESCRIPTION
# Description

Fixes a Bugbot finding from #403: both native bridges silently swallowed a subscription channel value that was present but the wrong type (e.g. a string instead of an array), with no diagnostic log, unlike every other malformed-input case in the same code path.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

_No native unit test harness exists for this bridge module today (no Android test source set, no XCTest target covering this file), so there's nothing to add tests to — this mirrors existing coverage for the surrounding function._

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

This targets `rel/2.5.0` directly since it fixes a bug introduced by unreleased code already on that branch (subscription methods added in #400).

## Changelog / Code Overview

`ReadableMap.parseConsentSet` (Android, `KlaviyoReactNativeSdkModule.kt`) and `consentValues(from:key:)` (iOS, `KlaviyoBridge.swift`) both collapsed two distinct cases into the same silent `null`/`nil` return: the channel key being absent from the payload, and the channel key being present but not an array. Every other malformed-input branch in this function (non-string array entry, unrecognized enum value, non-object `channels`) logs a warning; this one didn't, so e.g. `channels: { email: "marketing" }` (string instead of `["marketing"]`) was treated identically to omitting `email` entirely — silently left untouched with zero diagnostic on either platform.

Fix, on both platforms: keep "key absent" silent (expected — leave the channel untouched), but log a warning when the key is present with the wrong type before falling back to the same untouched-channel behavior.

## Test Plan

Manual repro (documented, not automated — no native test harness covers this bridge module):
1. Call `Klaviyo.createSubscription({ listId, channels: { email: "marketing" } })` (string, not array) via a native test harness or by bypassing the TS-layer type check.
2. Before the fix: no log output, `email` channel silently left untouched.
3. After the fix: `Warning: Ignoring non-array email consent value` logged on both Android and iOS, channel still left untouched (no behavior change in the actual consent applied — this is a diagnostics-only fix).

Verified `ktlint` and `swiftlint` pass on the changed files with no new violations (pre-existing `file_length`/`line_length`/`cyclomatic_complexity` warnings in `KlaviyoBridge.swift` predate this change).

## Related Issues/Tickets

- [MAGE-1084](https://linear.app/klaviyo/issue/MAGE-1084)
- Bugbot finding: https://github.com/klaviyo/klaviyo-react-native-sdk/pull/403#discussion_r3784724664
