### PR TITLE
fix: reject subscription channels with no recognized key or unknown keys

### DIFF
--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -129,6 +129,9 @@ const EMAIL_CONSENT_VALUES: readonly string[] = Object.values(EmailConsent);
 const MESSAGING_CONSENT_VALUES: readonly string[] =
   Object.values(MessagingConsent);
 
+/** Keys {@link SubscriptionChannels} recognizes; anything else is a caller mistake. */
+const SUPPORTED_CHANNELS = ['email', 'sms', 'whatsapp'] as const;
+
 /**
  * Validates one channel's consent list, returning an error message or `null` when it is valid.
  */
@@ -194,6 +197,30 @@ export function validateSubscription(
       'Subscription channels is required, and must be an object of per-channel consent or ' +
       'ALL_AVAILABLE_MARKETING. Use allAvailableMarketing(listId) to request marketing consent ' +
       'on every identified channel.'
+    );
+  }
+
+  // Channels is an object, so a caller can still hand it zero recognized keys (`{}`) or a
+  // misspelled one (`{ smss: [...] }`). Both would otherwise pass through as "no channel
+  // requested" and reach native as a subscription that grants no consent at all, with the caller
+  // never told why. Catch both here rather than validating only the keys we happen to recognize.
+  const channelKeys = Object.keys(channels);
+  type SupportedChannel = (typeof SUPPORTED_CHANNELS)[number];
+  const isSupportedChannel = (key: string): key is SupportedChannel =>
+    (SUPPORTED_CHANNELS as readonly string[]).includes(key);
+  const unsupportedChannels = channelKeys.filter(
+    (key) => !isSupportedChannel(key)
+  );
+  if (unsupportedChannels.length > 0) {
+    return `Subscription channels contains unsupported channels: ${unsupportedChannels.join(
+      ', '
+    )}. Supported: ${SUPPORTED_CHANNELS.join(', ')}`;
+  }
+
+  if (channelKeys.length === 0) {
+    return (
+      'Subscription channels must request consent on at least one channel, or use ' +
+      'ALL_AVAILABLE_MARKETING to request marketing consent on every identified channel.'
     );
   }
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1046,6 +1046,44 @@ describe('Klaviyo SDK', () => {
       }
     );
 
+    // A validly-typed channels object can still request nothing, either because every key was
+    // omitted or because a key was misspelled. Either way the request would otherwise reach
+    // native as a subscription that grants no consent, with the caller never told why.
+    it('should reject an empty channels object rather than granting no consent silently', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(() =>
+        Klaviyo.createSubscription({ listId: 'ABC123', channels: {} })
+      ).not.toThrow();
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.createSubscription
+      ).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('at least one channel')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should reject an unrecognized channel key rather than silently dropping it', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(() =>
+        Klaviyo.createSubscription({
+          listId: 'ABC123',
+          channels: { smss: [MessagingConsent.Marketing] } as never,
+        })
+      ).not.toThrow();
+
+      expect(
+        NativeModules.KlaviyoReactNativeSdk.createSubscription
+      ).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('smss')
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
     it('should reject a non-string listId rather than throwing on .trim()', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 


### PR DESCRIPTION
# Description

Fixes a CodeRabbit finding from #403: the TypeScript layer's `validateSubscription` never rejected a `channels` object with zero recognized keys or an unrecognized (e.g. misspelled) key, letting both silently produce a subscription request that grants no consent.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

This is TypeScript-layer validation shared by both platforms, so there's no per-platform parity concern here (unlike #404/#405).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

This targets `rel/2.5.0` directly since it fixes a bug introduced by unreleased code already on that branch (subscription methods added in #400).

## Changelog / Code Overview

`validateSubscription` in `src/Subscription.ts` destructures `{ email, sms, whatsapp }` from `channels` and validates each key only if present, but never checked whether *any* recognized key was actually given, and never flagged unrecognized keys. Two inputs therefore passed validation and produced a request that grants no consent:

- `channels: {}` — bridged as `channels: {}`, which the native SDK turns into a `Channels` value with every field `null`.
- `channels: { smss: ['marketing'] }` (misspelled key) — the typo'd key is silently dropped by `formatSubscription`, so the caller gets no error and no consent, with no indication why.

Every other malformed-input case in this function (wrong-typed `channels`, wrong-typed consent list, unsupported consent value) already returns a descriptive error — this was the one gap.

Added a `SUPPORTED_CHANNELS` list and, before destructuring, reject any `channels` object containing an unrecognized key, then reject one with zero keys — both with descriptive messages consistent with the rest of the function.

## Test Plan

Added two test cases to `src/__tests__/index.test.tsx` (neither case was previously covered — the existing parametrized "reject channels that is %s" test only covers wrong-*type* channels: string/number/array/null/boolean, not a validly-typed-but-empty-or-unrecognized object):
- `channels: {}` → rejected with an error mentioning "at least one channel", native bridge never called.
- `channels: { smss: [...] }` → rejected with an error naming the unsupported key, native bridge never called.

Full suite (`npx jest`) passes: 79/79. `tsc --noEmit` and `eslint` clean on changed files.

## Related Issues/Tickets

- [MAGE-1087](https://linear.app/klaviyo/issue/MAGE-1087)
- CodeRabbit finding: https://github.com/klaviyo/klaviyo-react-native-sdk/pull/403#discussion_r3805935464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription validation by rejecting unsupported channel names.
  * Added validation for subscriptions with no recognized channels.
  * Invalid subscriptions now return clear errors without triggering the native subscription bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->