### PR TITLE
fix: remove stale temporary Android SDK pin comments

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,10 +17,6 @@ android.useAndroidX=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Tue Dec 19 15:08:27 EST 2023
-# TEMPORARY - PIN BACK TO "4.5.0" ONCE THE ANDROID SDK RELEASE PUBLISHES (MAGE-856)
-# Klaviyo.createSubscription ships in 4.5.0, which is cut on rel/4.5.0 but not yet released.
-# JitPack (declared as a repository in android/build.gradle) builds the branch on demand under
-# the same group; '/' is escaped as '~' in the version string.
 KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion=4.5.0
 KlaviyoReactNativeSdk_kotlinVersion=1.8.0
 KlaviyoReactNativeSdk_minSdkVersion=23


### PR DESCRIPTION
# Description

Removes leftover comments in `android/gradle.properties` describing a temporary JitPack branch pin for the Android SDK that has since published as a real release.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

`android/gradle.properties` pinned `KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion` to `4.5.0` with a `TEMPORARY`/`MAGE-856` comment block explaining that this was a JitPack build of the `rel/4.5.0` branch ahead of an official Android SDK release. `klaviyo-android-sdk` `4.5.0` has since published as a real tag, so the pin now resolves a normal release and the surrounding commentary is stale/misleading — this mirrors the equivalent iOS cleanup already merged in #390 (flagged by Bugbot as a similarly-stale comment: https://github.com/klaviyo/klaviyo-react-native-sdk/pull/403#discussion_r3807285534).

No functional change — `4.5.0` remains the pinned version, only the outdated explanatory comments are removed.

## Test Plan

Comment-only change to a properties file; no build behavior changes (verified `4.5.0` is an existing tag on `klaviyo/klaviyo-android-sdk`).

## Related Issues/Tickets

Follow-up to review feedback on #390 / #403:
- https://github.com/klaviyo/klaviyo-react-native-sdk/pull/390#discussion_r3807031406
- https://github.com/klaviyo/klaviyo-react-native-sdk/pull/403#discussion_r3807285534