### PR TITLE
docs: reflect three-valued automatic_push_token_forwarding on Android [MAGE-1114]

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -11,7 +11,7 @@ different from setting it to `false`:
 
 | Value | Behavior |
 |---|---|
-| **not set** (default) | The native SDK forwards a token whenever FCM delivers one to its bundled `KlaviyoPushService`. This is the SDK's original behavior and requires no manifest changes. |
+| **not set** (default) | The native SDK forwards a token whenever FCM delivers one to its bundled `KlaviyoPushService`. This is the SDK's original behavior and requires no manifest changes. On React Native, `Klaviyo.initialize()` runs from JS after `Application.onCreate`, so a token FCM delivers before that call is silently dropped. |
 | **`true`** | Additionally fetches and registers the current token at `Klaviyo.initialize()` and on each foreground. |
 | **`false`** | No automatic forwarding at all — call `Klaviyo.setPushToken(...)` yourself. |
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -4,45 +4,33 @@ This guide outlines how developers can migrate from older versions of our SDK to
 
 ## Migrating to v2.5.0
 
-### Automatic push token forwarding is now the default on Android
+### Android's `automatic_push_token_forwarding` flag is now three-valued
 
-As of v2.5.0 (which pins the native Android SDK to 4.5.0), the Klaviyo SDK forwards the Android FCM
-push token to Klaviyo **automatically by default**. This formalizes behavior the bundled
-`KlaviyoPushService` already performed — see the native
-[Android SDK README](https://github.com/klaviyo/klaviyo-android-sdk#Push-Notifications) for details —
-and is **non-breaking**, because the default preserves existing behavior.
+On Android, `automatic_push_token_forwarding` has three states, because leaving it unset is
+different from setting it to `false`:
 
-**iOS is unchanged:** automatic forwarding remains opt-in (off by default), because iOS token
-collection relies on the more invasive app-delegate method swizzling. Each platform has its own key —
-`klaviyo_automatic_push_token_forwarding` in the iOS `Info.plist` and
-`com.klaviyo.push.automatic_push_token_forwarding` in the Android manifest — with the same meaning
-(`false` = no automatic collection) but different defaults, for these platform-specific reasons.
+| Value | Behavior |
+|---|---|
+| **not set** (default) | The native SDK forwards a token whenever FCM delivers one to its bundled `KlaviyoPushService`. This is the SDK's original behavior and requires no manifest changes. |
+| **`true`** | Additionally fetches and registers the current token at `Klaviyo.initialize()` and on each foreground. |
+| **`false`** | No automatic forwarding at all — call `Klaviyo.setPushToken(...)` yourself. |
 
-**No action is required** to keep current behavior. If you prefer to own the push-token pipeline
-yourself:
+**No action is required** to keep current behavior — the unset default matches what this SDK has
+always done. If you prefer to own the push-token pipeline entirely, set the flag to `false` and
+continue calling `Klaviyo.setPushToken(...)` yourself:
 
-- **Android** — disable automatic forwarding by adding this `meta-data` to the `<application>`
-  element of your `AndroidManifest.xml`, then continue calling `Klaviyo.setPushToken(...)` yourself:
+```xml
+<meta-data
+    android:name="com.klaviyo.push.automatic_push_token_forwarding"
+    android:value="false" />
+```
 
-  ```xml
-  <meta-data
-      android:name="com.klaviyo.push.automatic_push_token_forwarding"
-      android:value="false" />
-  ```
+See the [README](./README.md#collecting-push-tokens) for full token-collection guidance.
 
-- **iOS** — nothing to do; automatic forwarding is off unless you opt in via `Info.plist` (see the
-  native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications)).
-
-If you already collect and set the token manually on Android, no change is needed — the native SDK
-only sends a request when the complete push request state has changed. See the
-[README](./README.md#collecting-push-tokens) for full token-collection guidance.
-
-> **Looking ahead:** a future **major** release may enable **both** `automatic_push_open_tracking`
-> and `automatic_push_token_forwarding` by default on all platforms, bringing automatic push
-> integration to parity. If that happens, apps that prefer to manage push integration manually would
-> need to **opt out** of the enabled defaults (as described above for Android), rather than opt in.
-> This is a non-breaking, forward-looking heads-up — nothing changes until that release, and we will
-> document the exact opt-out steps in its migration guide.
+> **Looking ahead:** a future **major** release may default `automatic_push_token_forwarding` to
+> `true` (in addition to enabling `automatic_push_open_tracking` by default), bringing automatic
+> push integration to parity across platforms. This is a non-breaking, forward-looking heads-up —
+> nothing changes until that release.
 
 ## Migrating to v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ unset is different from setting it to `false`:
 
 | Value | Behavior |
 |---|---|
-| **not set** (default) | Forwards a token whenever FCM delivers one to `KlaviyoPushService`. |
+| **not set** (default) | Forwards a token whenever FCM delivers one to `KlaviyoPushService`. On React Native, `Klaviyo.initialize()` runs from JS after `Application.onCreate`, so a token FCM delivers before that call is silently dropped. |
 | **`true`** | Additionally fetches and registers the current token at `Klaviyo.initialize()` and on each foreground. |
 | **`false`** | No automatic forwarding at all — a complete opt-out. |
 

--- a/README.md
+++ b/README.md
@@ -356,15 +356,24 @@ Note that doing this in one location is sufficient.
 Before choosing an approach, note that the underlying native SDKs handle automatic push-token
 forwarding differently by default:
 
-- **Android — on by default.** The native Android SDK auto-registers its `KlaviyoPushService`
-  (a `FirebaseMessagingService`) via manifest merge, so it forwards the FCM token to Klaviyo
-  automatically, without any React Native code. You do not need to collect the token yourself on
-  Android — though doing so is harmless: the native SDK only sends a request when the complete push
-  request state has changed.
+- **Android — reactive forwarding by default, proactive fetch opt-in.** The native Android SDK
+  auto-registers its `KlaviyoPushService` (a `FirebaseMessagingService`) via manifest merge, so it
+  forwards a token to Klaviyo whenever FCM delivers one, without any React Native code. You do not
+  need to collect the token yourself on Android — though doing so is harmless: the native SDK only
+  sends a request when the complete push request state has changed.
 - **iOS — opt-in (off by default).** iOS token forwarding relies on app-delegate method swizzling,
   which is more invasive, so the native iOS SDK does not enable it implicitly. By default you set the
   APNs token manually, as shown below. Automatic forwarding on iOS is opt-in via `Info.plist` — see
   the native [iOS README](https://github.com/klaviyo/klaviyo-swift-sdk#Push-Notifications).
+
+On Android, `com.klaviyo.push.automatic_push_token_forwarding` is three-valued, because leaving it
+unset is different from setting it to `false`:
+
+| Value | Behavior |
+|---|---|
+| **not set** (default) | Forwards a token whenever FCM delivers one to `KlaviyoPushService`. |
+| **`true`** | Additionally fetches and registers the current token at `Klaviyo.initialize()` and on each foreground. |
+| **`false`** | No automatic forwarding at all — a complete opt-out. |
 
 Each platform has its own key — `klaviyo_automatic_push_token_forwarding` in the iOS `Info.plist` and
 `com.klaviyo.push.automatic_push_token_forwarding` in the Android manifest — with the same meaning


### PR DESCRIPTION
# Description

Android's `automatic_push_token_forwarding` manifest flag is now three-valued (unset/true/false) instead of a boolean defaulting to `true`. This updates the README and migration guide accordingly — no code changes.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [ ] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

N/A — docs only, no runtime code changed.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] Contains readme or migration guide changes.
  - Targeting `rel/2.5.0` directly (not `master`) so this lands with the official 2.5.0 release, alongside the Android SDK version bump.
- [x] This is planned work for an upcoming release (2.5.0).

## Changelog / Code Overview

- `MIGRATION_GUIDE.md`: replaced the "Automatic push token forwarding is now the default on Android" section with a description of the three-valued flag (not set / `true` / `false`) and what each state does.
- `README.md`: updated "Automatic Token Forwarding (Platform Defaults)" — the Android bullet no longer claims "on by default" outright; added a table of the three states. iOS content is untouched.

Does not reference the native Android SDK version by number, since 4.5.0 never shipped in a wrapper release — framed purely around the flag's behavior. Does not touch the pinned native Android SDK version in `gradle.properties`; that will be handled separately once the corresponding native release ships.

## Test Plan

Docs only — reviewed rendered Markdown for the changed sections.

## Related Issues/Tickets

MAGE-1114
Native Android SDK PR: https://github.com/klaviyo/klaviyo-android-sdk/pull/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android migration guidance for `automatic_push_token_forwarding`.
  * Documented unset, enabled, and disabled configuration behaviors.
  * Added instructions for opting out through the Android manifest.
  * Clarified default token-forwarding behavior and linked to related token guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->