### PR TITLE
chore(deps): consolidate protobufjs, ip-address and js-yaml npm bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "resolutions": {
     "@types/react": "^19.1.0",
-    "protobufjs": "^7.6.4"
+    "protobufjs": "^7.6.5"
   },
   "peerDependencies": {
     "react": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8998,14 +8998,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: ^1.0.7
     esprima: ^4.0.0
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 0209830c3ce51cec4c2cefee4b2b68c547b56b36920004efbf7c6a91ae7eee784bf64341738ef1acffa975d16e7882e9b69234b9a4411f455b72b33d4d74771e
+  checksum: 536cfb984b61d1544dbdbe394254dd13481a94171cb3a61608572d9112a63cbace9dd900cb83a4e530ac36427fff77d9e1cb6734917c6fea951d00b4f7bbb163
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7873,9 +7873,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 04e729990bc597bb0c86a02f71ffb8a19a47cd78e635209923079137fa06b8a27291d62fdddfeaf67b8e710ee51c46d2bbee1d1bf92f5101305e8276359c3df6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11300,9 +11300,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.6.4":
-  version: 7.6.4
-  resolution: "protobufjs@npm:7.6.4"
+"protobufjs@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -11315,7 +11315,7 @@ __metadata:
     "@protobufjs/utf8": ^1.1.1
     "@types/node": ">=13.7.0"
     long: ^5.3.2
-  checksum: 2cee14aa83c6688bf3c2d80ce9a6b904dfdaf10294fd131c388b94aed8028fc6ad74aea9b56aad4e2db3d278e36e40d5e15ba76925ba846bd654ffef218ee8fc
+  checksum: 6d3f18324942f8cabf003b68b81a445e8089a3f89cfae227feedbe4bfe8aea8629f6332cbe6176842cbe645704e4a25d4773b55c3b63d923034b3e6b4eacbb78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Consolidates three pending Dependabot npm bumps into a single PR — one CI run and one review instead of three. Supersedes #385, #395, and #399.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — transitive dev-dependency bumps with no runtime surface. Verified via the full CI gate set locally (see Test Plan).
- [x] I have added sufficient unit/integration tests of my changes.
  - N/A — dependency version bumps, no behavior change. Existing suite (79 tests) passes unchanged.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
  - N/A
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - N/A — JS toolchain deps only, no native code touched.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [ ] This is planned work for an upcoming release.
  - Dependency hygiene, not planned feature work. No release plan impact — none of these packages ship in the published artifact; all three are build/dev-time transitives.

## Changelog / Code Overview

Each bump is the exact version Dependabot proposed, cherry-picked from the Dependabot commits rather than hand-edited, so the resolved versions and checksums are provably unmodified.

| Supersedes | Package | From → To | Why |
|---|---|---|---|
| #385 | `protobufjs` | 7.6.4 → 7.6.5 | Bug fix: handle EOF during options parsing (protobufjs/protobuf.js#2356) |
| #395 | `ip-address` | 10.2.0 → 10.4.0 | Byte-array validation for `Address6`, node 12 loadability |
| #399 | `js-yaml` | 3.15.0 → 3.15.1 | **Security**: removes quadratic complexity from `!!omap` duplicate-key detection |

Total diff: 4 changed lines across 2 files.

### One `package.json` edit is required, by design

`protobufjs` is not a plain transitive — it's a **`resolutions` pin** in the root `package.json`. The lock descriptor is keyed on that range (`protobufjs@npm:^7.6.4`), so bumping `yarn.lock` alone leaves the lockfile out of sync and `yarn install --immutable` fails. Dependabot's own commit for #385 bumps the pin to `^7.6.5`; that's the single `package.json` line in this diff.

`ip-address` and `js-yaml` are `yarn.lock`-only.

No other lockfile entries were touched. Note that `js-yaml@npm:^4.1.0` (resolving to 4.1.1) is a separate descriptor and is intentionally left alone — Dependabot only proposed the `^3.13.1` tree.

### Why #399's red CI did not block this

#399 was failing `compile-ios-new-arch / build-ios` ([job log](https://github.com/klaviyo/klaviyo-react-native-sdk/actions/runs/31549481323/job/93968843401)). The failure is runner infrastructure, not the bump — it dies in `pod install`:

```
Installing SocketRocket (0.7.1)
[!] Error installing SocketRocket
[!] /opt/homebrew/bin/git clone https://github.com/facebook/SocketRocket.git ... --branch 0.7.1
fatal: unable to access 'https://github.com/facebook/SocketRocket.git/': SSL certificate problem: self signed certificate
```

A TLS-interception problem on the macOS runner while CocoaPods cloned a pod from GitHub. Three reasons it isn't the dependency:

1. The bump is a 3-line `yarn.lock` change to a transitive JS package. `js-yaml` has no involvement in a CocoaPods `git clone`.
2. `compile-ios-old-arch / build-ios` **passed** on that same commit — identical lockfile and Podfile, different runner.
3. That run is from 2026-08-12. Every `iOS CI` run since (`rel/2.5.0`, `aw/mage-1085-safe-area`, `gb/auto-push-*`, `aw/mage-1119-android-4.5.1`) has been green.

So `js-yaml` stays in the bundle — and it's the one bump here with a security advisory behind it, so dropping it would have been the wrong trade. CI on this PR is the real verdict.

## Test Plan

Full CI gate set run locally against this branch:

| Gate | Result |
|---|---|
| `yarn install --immutable` | pass — lockfile in sync with `package.json`, working tree clean afterward |
| `yarn typecheck` | pass |
| `yarn lint` | pass — 4 pre-existing SwiftLint warnings, 0 serious, none from this diff |
| `yarn test` | pass — 79/79 |
| `yarn prepare` (CI `build-library`) | pass |
| `yarn attw` | pass — "No problems found", all 4 resolution modes green |

The lockfile-sync check is the meaningful one here: it's what would break if a bump were applied incorrectly, and it's what CI gates on.

## Related Issues/Tickets

Supersedes and should close on merge:

- #385 — `chore(deps): bump protobufjs from 7.6.4 to 7.6.5`
- #395 — `chore(deps): bump ip-address from 10.2.0 to 10.4.0`
- #399 — `chore(deps): bump js-yaml from 3.15.0 to 3.15.1`

Deliberately **not** folded in:

- #391 (`brace-expansion`) and #392 (`ws`) — already approved and mergeable on their own; merging separately.
- #376 (`concurrent-ruby`) — Bundler, scoped to `/example`. Different ecosystem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Protocol Buffers library to a newer patch version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->