### PR TITLE
chore(release): open 2.5.1 for the forms session-timeout cascade [MAGE-1181]

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.5.0</string>
+  <string name="klaviyo_sdk_version_override">2.5.1</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.5.0"
+        versionName "2.5.1"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
## Summary

Opens the React Native half of the MAGE-1180 wrapper cascade and bumps the SDK version to **2.5.1** on the `rel/2.5.1` release branch.

**This PR is a placeholder.** It currently carries only the version bump. The actual cascade — raising the pinned native SDK versions to pick up the forms session-timeout fix — cannot be written yet.

## Blocked on

MAGE-1177 (fix the session timeout bug on iOS) has not started, so there is no `klaviyo-swift-sdk` release carrying the fix to pin. Current pins on `master`, unchanged by this PR:

| Where | Dependency | Pinned at |
| --- | --- | --- |
| `klaviyo-react-native-sdk.podspec` | `KlaviyoSwift`, `KlaviyoForms`, `KlaviyoLocation` | `5.4.0` |
| `android/gradle.properties` | `KlaviyoReactNativeSdk_klaviyoAndroidSdkVersion` | `4.5.1` |

## What this PR contains

`./bump-version.sh -v 2.5.1 --skip-native --skip-install` — version strings only, no dependency changes:

- `package.json`
- `ios/klaviyo-sdk-configuration.plist`
- `android/src/main/res/values/strings.xml` (`klaviyo_sdk_version_override`)
- `example/android/app/build.gradle` (`versionName`)
- `example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj` (`MARKETING_VERSION`)

## Remaining work before this leaves draft

- [ ] MAGE-1177 lands and a `klaviyo-swift-sdk` version ships with the fix
- [ ] Re-pin the native versions (`./bump-version.sh -v 2.5.1 -s <swift> -a <android>`)
- [ ] Confirm the cascade needs no wrapper-side bridge changes — if it does, this stops being a patch and 2.5.1 needs revisiting
- [ ] Smoke-test the example app on both platforms against the behavior the fix claims to repair
- [ ] `./pack-and-test.sh`

## Release

Tracked separately. `rel/2.5.1` is tagged and released via a **GitHub Release** — `publish-sdk.yml` fires on `release: [published]`, which is what pushes to npm. A pushed tag alone publishes nothing.

Refs MAGE-1181, MAGE-1180, MAGE-1177
