### PR TITLE
chore(release): merge rel/2.5.1 into master [MAGE-1183]

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.5.0</string>
+  <string name="klaviyo_sdk_version_override">2.5.1</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.5.0"
+        versionName "2.5.1"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,21 +63,21 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.5.0):
-    - KlaviyoForms (= 5.4.0)
-    - KlaviyoLocation (= 5.4.0)
-    - KlaviyoSwift (= 5.4.0)
+  - klaviyo-react-native-sdk (2.5.1):
+    - KlaviyoForms (= 5.4.1)
+    - KlaviyoLocation (= 5.4.1)
+    - KlaviyoSwift (= 5.4.1)
     - React-Core
-  - KlaviyoCore (5.4.0):
+  - KlaviyoCore (5.4.1):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.4.0):
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoLocation (5.4.0):
-    - KlaviyoSwift (~> 5.4.0)
-  - KlaviyoSwift (5.4.0):
+  - KlaviyoForms (5.4.1):
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoLocation (5.4.1):
+    - KlaviyoSwift (~> 5.4.1)
+  - KlaviyoSwift (5.4.1):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoSwiftExtension (5.4.0)
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoSwiftExtension (5.4.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2811,15 +2811,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 964b9055637c18a7231e8e73372ebb1cd945deb0
-  KlaviyoCore: 4b87a84a10a44110b4ec73459d91f63941bedb47
-  KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
-  KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 07ddea8bee2a80a5e8e25e23231008eb59f2da71
-  KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
+  klaviyo-react-native-sdk: b8cfe736e5f8d026890953a3d4800309055dc289
+  KlaviyoCore: 252a62ea36e47109e92bd376b0a1c4026b956e75
+  KlaviyoForms: b9767202597c87c1637969f1070903fd7fecfc7e
+  KlaviyoLocation: d69799af58502deb4ce5ce47fec7b6b7e5791f4f
+  KlaviyoSwift: fabd2b2da05f9e7e32ab0d23b560eb90640196b6
+  KlaviyoSwiftExtension: 2f5b9348e2198af88c6bd5189123865732a0ae7c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.4.0"
+  s.dependency "KlaviyoSwift", "5.4.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.4.0"
+    s.dependency "KlaviyoLocation", "5.4.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.4.0"
+    s.dependency "KlaviyoForms", "5.4.1"
   end
 
   s.default_subspecs = :none

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
## Summary

Merge-back for the **2.5.1** release. Tracked in MAGE-1183.

**Do not merge until 2.5.1 is tagged and published.** In this repo the release order is: land the work on `rel/2.5.1` → tag the branch tip → publish a GitHub Release (that is what pushes to npm) → *then* merge this PR. Merging early puts the version bump on `master` while npm still has 2.5.0.

## Current contents

Only the version bump so far (`5203d86`). The actual cascade — raising the pinned native SDK versions for the MAGE-1177 forms session-timeout fix — is still to come via PR #413, and will appear here once it lands on `rel/2.5.1`.

## Precedent

The 2.5.0 merge-back was a squash onto `master` (`a9a68fe` "rel/2.5.0 (#403)"). Worth matching so `master`'s history stays one-commit-per-release.

Skipping the merge-back is how `rel/2.4.2` ended up orphaned on origin with `package.json` still at `2.4.1` and no tag.

Refs MAGE-1183, MAGE-1181, MAGE-1180
