### PR TITLE
fix(ios): cascade the forms session-timeout fix — pin klaviyo-swift-sdk 5.4.1 [MAGE-1181]

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,21 +63,21 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.5.0):
-    - KlaviyoForms (= 5.4.0)
-    - KlaviyoLocation (= 5.4.0)
-    - KlaviyoSwift (= 5.4.0)
+  - klaviyo-react-native-sdk (2.5.1):
+    - KlaviyoForms (= 5.4.1)
+    - KlaviyoLocation (= 5.4.1)
+    - KlaviyoSwift (= 5.4.1)
     - React-Core
-  - KlaviyoCore (5.4.0):
+  - KlaviyoCore (5.4.1):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.4.0):
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoLocation (5.4.0):
-    - KlaviyoSwift (~> 5.4.0)
-  - KlaviyoSwift (5.4.0):
+  - KlaviyoForms (5.4.1):
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoLocation (5.4.1):
+    - KlaviyoSwift (~> 5.4.1)
+  - KlaviyoSwift (5.4.1):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoSwiftExtension (5.4.0)
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoSwiftExtension (5.4.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2811,15 +2811,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 964b9055637c18a7231e8e73372ebb1cd945deb0
-  KlaviyoCore: 4b87a84a10a44110b4ec73459d91f63941bedb47
-  KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
-  KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 07ddea8bee2a80a5e8e25e23231008eb59f2da71
-  KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
+  klaviyo-react-native-sdk: b8cfe736e5f8d026890953a3d4800309055dc289
+  KlaviyoCore: 252a62ea36e47109e92bd376b0a1c4026b956e75
+  KlaviyoForms: b9767202597c87c1637969f1070903fd7fecfc7e
+  KlaviyoLocation: d69799af58502deb4ce5ce47fec7b6b7e5791f4f
+  KlaviyoSwift: fabd2b2da05f9e7e32ab0d23b560eb90640196b6
+  KlaviyoSwiftExtension: 2f5b9348e2198af88c6bd5189123865732a0ae7c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.4.0"
+  s.dependency "KlaviyoSwift", "5.4.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.4.0"
+    s.dependency "KlaviyoLocation", "5.4.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.4.0"
+    s.dependency "KlaviyoForms", "5.4.1"
   end
 
   s.default_subspecs = :none


### PR DESCRIPTION
# Description

Cascades the in-app forms session-expiry fix from `klaviyo-swift-sdk` 5.4.1 into the React Native SDK for the **2.5.1** patch release. This is a native pin bump only — no TypeScript or bridge changes are required.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

**Testing status — please read before approving.** The device smoke test has **not** been run yet. The behaviour this release repairs is only observable by expiring a forms session on a device, so CI passing does not prove the cascade worked. See the Test Plan below.

No new tests were added because no first-party code changed. Android parity already holds: upstream swift PR #715 states the fix brings iOS to parity with `klaviyo-android-sdk`, which is why the Android pin does not move.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.

Patch is the correct level. Upstream PR #715 is explicit that its changes are internal to `IAFPresentationManager` with no public API changes, and nothing in this repo's public surface moves.

## Changelog / Code Overview

Two files:

| File | Change |
| --- | --- |
| `klaviyo-react-native-sdk.podspec` | `KlaviyoSwift`, `KlaviyoLocation`, `KlaviyoForms` pinned `5.4.0` → `5.4.1` |
| `example/ios/Podfile.lock` | regenerated via `pod update`; all five Klaviyo pods now resolve at `5.4.1` |

### Why no wrapper code changes

The podspec pins exact versions, so the bump has to be explicit. Beyond that, the fix reaches consumers through the pinned pod alone:

- The only session-timeout surface is `sessionTimeoutDuration` (`src/Forms.ts:33`), which both bridges pass straight through to the native `InAppFormsConfig` initializer — `ios/KlaviyoBridge.swift:89-90` and `KlaviyoReactNativeSdkModule.kt:146-149`.
- Upstream PR #715 changes only `IAFPresentationManager` internals and does not alter `InAppFormsConfig`'s public shape, so none of those three files need to move.

### What the upstream fix repairs

When a form session expired, the old expiry path destroyed only the webview. On the rebuilt webview's handshake, `startProfileObservation()`'s idempotency guard saw a still-live observer and short-circuited, so the fresh webview never re-subscribed to the event bus and trigger-based forms silently stopped firing. 5.4.1 adds a scoped `tearDownFormWebView()` that clears the observer and its tasks first, plus two adjacent lifecycle repairs.

### Deliberately not changed

- `android/gradle.properties` stays at `4.5.1`. The bug was iOS only, and `4.5.1` is the newest Android release.
- `package.json`, the iOS plist, Android `strings.xml`, and the example app version strings are already at `2.5.1` from `5203d86` on `rel/2.5.1`. They are not re-bumped here.

### One incidental line

`example/ios/Podfile.lock` also shows an `RCT-Folly` checksum change with its version unchanged at `2024.11.18.00`. React Native is `0.81.5` in both `example/package.json` and `node_modules`, so this is not a version skew — the previously committed lock was generated against a slightly different local podspec state. Flagging it rather than hand-editing one checksum back, which would leave the lock inconsistent with what `pod install` actually computes.

## Test Plan

**Not yet executed.** Reviewers should treat this as outstanding.

1. Lower `sessionTimeoutDuration` in `example/src/hooks/useForms.ts` from `3600` to about `30`.
2. Run the example app on an iOS simulator and register for in-app forms.
3. Configure a form that triggers on a tracked event.
4. Background the app for longer than the timeout, then foreground it.
5. Fire the trigger event and confirm the form appears.
6. Repeat the background/foreground cycle a second time and confirm the form still appears.
7. Revert the `sessionTimeoutDuration` edit.

Run the same steps once on Android as a regression check — the Android pin does not move, so the result must be unchanged. Then verify a third-party install resolves the new pod with `./pack-and-test.sh setup` followed by an example app build.

## Related Issues/Tickets

- MAGE-1181 — this ticket, the React Native half of the cascade
- MAGE-1180 — parent, cascade to both wrappers
- MAGE-1177 — the origin iOS fix
- MAGE-1183 — 2.5.1 release mechanics
- Upstream: https://github.com/klaviyo/klaviyo-swift-sdk/pull/715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting Klaviyo components to version 5.4.1.
  * Existing optional component controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->