### PR TITLE
chore: add pr-target-check workflow

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -1,0 +1,85 @@
+name: PR Target Branch Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+jobs:
+  check-pr-target:
+    name: Check PR targets a release branch
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Validate source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          LABEL: 'needs: release branch'
+        run: |
+          # If PR doesn't target master, this check doesn't apply — clean up any stale label and pass
+          if [[ "$BASE_REF" != "master" ]]; then
+            echo "PR targets '$BASE_REF' (not master) — check not required."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          if [[ "$HEAD_REF" == rel/* ]] || [[ "$HEAD_REF" == ci/* ]] || [[ "$HEAD_REF" == docs/* ]] || [[ "$HEAD_REF" == dependabot/* ]]; then
+            echo "Branch '$HEAD_REF' is allowed to target master."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # A conventional-commit PR title is another valid path: ci, chore, docs, or rel
+          # (case-insensitive, optional scope and breaking-change marker, e.g. "ci(workflows)!: ...")
+          TITLE_LC=$(printf '%s' "$PR_TITLE" | tr '[:upper:]' '[:lower:]')
+          TITLE_REGEX='^(ci|chore|docs|rel)(\([^)]*\))?!?:[[:space:]]'
+          if [[ "$TITLE_LC" =~ $TITLE_REGEX ]]; then
+            echo "PR title '$PR_TITLE' has an allowed conventional-commit prefix — allowed to target master."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # Check for manual-merge override label
+          HAS_OVERRIDE=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq '.[] | select(.name == "manual-merge") | .name' | head -1)
+
+          if [ -n "$HAS_OVERRIDE" ]; then
+            echo "manual-merge label present — bypassing check. This PR will merge directly to master without a release branch."
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$LABEL" 2>/dev/null || true
+            exit 0
+          fi
+
+          # Post a comment only if one hasn't been posted already
+          MARKER="<!-- pr-target-check-warning -->"
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+
+          if [ -z "$EXISTING" ]; then
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --method POST \
+              --field body="${MARKER}
+          **:warning: This PR needs to target a release branch before it can merge to \`master\`.**
+
+          All changes — including hotfixes and feature work — should flow through a \`rel/*\` branch rather than merging directly to \`master\`. This keeps commit history clean and ensures every change is tied to a release.
+
+          **To fix:** change the base branch of this PR to the appropriate \`rel/*\` branch when available. You can do this without closing the PR — use the base branch dropdown at the top of the PR.
+
+          - If this is CI/tooling work, rename your branch with a \`ci/\` prefix and this check will pass
+          - If this is documentation-only work, rename your branch with a \`docs/\` prefix and this check will pass
+          - Alternatively, give the PR a conventional-commit title prefixed with \`ci:\`, \`chore:\`, \`docs:\`, or \`rel:\` (scopes like \`ci(workflows):\` also work) and this check will pass
+
+          > **Override:** In exceptional circumstances, a maintainer may add the \`manual-merge\` label to bypass this check and merge directly to \`master\`. This should be used sparingly — it skips the release branch entirely and may result in changes not being included in a release or loss of commit attribution if not handled carefully.
+
+          _Enforced by the \`pr-target-check\` workflow._"
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "$LABEL"
+
+          echo "Branch '$HEAD_REF' cannot target master directly. Use a rel/*, ci/*, docs/*, or dependabot/* branch, a ci:/chore:/docs:/rel: PR title, or add the manual-merge label to override."
+          exit 1


### PR DESCRIPTION
# Description

Adds the `pr-target-check` workflow to the React Native SDK, bringing it to parity with `klaviyo-android-sdk` and `klaviyo-swift-sdk`, which already enforce that non-release work reaches `master` through a `rel/*` branch.

## Due Diligence

- [x] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
  - N/A — CI-only change, ships no SDK code.
- [x] I have added sufficient unit/integration tests of my changes.
  - N/A — a GitHub Actions workflow isn't unit-testable. Validation notes under Test Plan.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
  - N/A
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).
  - N/A — no platform code.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
  - Repo tooling only; nothing ships to consumers.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [ ] Contains readme or migration guide changes.
- [x] This is planned work for an upcoming release.
  - Tracked by MAGE-1189, one of three sibling tickets covering the hybrid repos.

## Changelog / Code Overview

One new file: `.github/workflows/pr-target-check.yml`, copied from `klaviyo-android-sdk`. Of the two existing copies, android's is the more robust — it quotes `"$PR_NUMBER"`/`"$REPO"` in its `gh pr edit` calls where swift-sdk left them bare. (That gap is fixed separately in klaviyo/klaviyo-swift-sdk#718, so all four repos now run a byte-identical workflow.)

A PR targeting `master` gets the `needs: release branch` label and fails, unless one of these applies:

- the head branch is `rel/*`, `ci/*`, `docs/*` or `dependabot/*`
- the PR title carries a `ci:`, `chore:`, `docs:` or `rel:` prefix
- a maintainer applies the `manual-merge` override label

PRs targeting anything other than `master` are unaffected, and a stale label is cleared on re-run.

**Also done outside this diff:** the `needs: release branch` and `manual-merge` labels were created in this repo, matching android's colors and descriptions. The workflow's `gh pr edit --add-label` call would fail at runtime without them.

## Test Plan

This PR is its own test case — it targets `master` from a `chore/*` branch, which is **not** in the branch allowlist, so it passes only via the `chore:` title path. A green check here exercises that branch of the logic end to end.

Also verified locally:

- YAML parses; the embedded shell script passes `bash -n`
- the title regex accepts `chore:`, `ci(workflows):`, `ci(workflows)!:`, capitalized `Chore:`, `docs:`, `rel:` and rejects `feat:`, `fix:`, `chores:`, and a bare `chore` with no colon
- the branch allowlist accepts `rel/`, `ci/`, `docs/`, `dependabot/` and rejects `chore/`, `feat/`, `gb/MAGE-1/x`
- `prettier --check` passes on the changed file (it normalizes one YAML quote style; confirmed parse-identical to android's copy)

To watch it work: retitle this PR to something like `feat: x` and re-run — it should fail and apply the label. Restoring the `chore:` title clears the label and passes.

## Related Issues/Tickets

- Part of MAGE-1189
- Siblings: MAGE-1188 (Flutter SDK), MAGE-1189 (React Native SDK), MAGE-1190 (Expo plugin)
- Swift quoting backport: klaviyo/klaviyo-swift-sdk#718
- Origin: [#mage Slack thread](https://klaviyo.slack.com/archives/C08GN96SF1B/p1783012401235149) on turning this on in the other repos

🔗 [View this job in Reca Studio](https://kiosk.klaviyo-dev.com/remote-coding-agent/flow/e7954c3b-654a-4787-83b8-988a77e7846c)
🤖 Generated with Reca


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated validation for pull requests targeting the main development branch.
  - Pull requests that meet approved criteria pass automatically.
  - Pull requests requiring attention now receive a warning and clear labeling when validation fails.
  - Pull requests targeting other branches continue without additional validation requirements, with outdated validation labels removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->