### PR TITLE
fix(ios): cascade the forms session-timeout fix — pin klaviyo-swift-sdk 5.4.1 [MAGE-1181]

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.5.0</string>
+  <string name="klaviyo_sdk_version_override">2.5.1</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.5.0"
+        versionName "2.5.1"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,21 +63,21 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.5.0):
-    - KlaviyoForms (= 5.4.0)
-    - KlaviyoLocation (= 5.4.0)
-    - KlaviyoSwift (= 5.4.0)
+  - klaviyo-react-native-sdk (2.5.1):
+    - KlaviyoForms (= 5.4.1)
+    - KlaviyoLocation (= 5.4.1)
+    - KlaviyoSwift (= 5.4.1)
     - React-Core
-  - KlaviyoCore (5.4.0):
+  - KlaviyoCore (5.4.1):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.4.0):
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoLocation (5.4.0):
-    - KlaviyoSwift (~> 5.4.0)
-  - KlaviyoSwift (5.4.0):
+  - KlaviyoForms (5.4.1):
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoLocation (5.4.1):
+    - KlaviyoSwift (~> 5.4.1)
+  - KlaviyoSwift (5.4.1):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoSwiftExtension (5.4.0)
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoSwiftExtension (5.4.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2811,15 +2811,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 964b9055637c18a7231e8e73372ebb1cd945deb0
-  KlaviyoCore: 4b87a84a10a44110b4ec73459d91f63941bedb47
-  KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
-  KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 07ddea8bee2a80a5e8e25e23231008eb59f2da71
-  KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
+  klaviyo-react-native-sdk: b8cfe736e5f8d026890953a3d4800309055dc289
+  KlaviyoCore: 252a62ea36e47109e92bd376b0a1c4026b956e75
+  KlaviyoForms: b9767202597c87c1637969f1070903fd7fecfc7e
+  KlaviyoLocation: d69799af58502deb4ce5ce47fec7b6b7e5791f4f
+  KlaviyoSwift: fabd2b2da05f9e7e32ab0d23b560eb90640196b6
+  KlaviyoSwiftExtension: 2f5b9348e2198af88c6bd5189123865732a0ae7c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.4.0"
+  s.dependency "KlaviyoSwift", "5.4.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.4.0"
+    s.dependency "KlaviyoLocation", "5.4.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.4.0"
+    s.dependency "KlaviyoForms", "5.4.1"
   end
 
   s.default_subspecs = :none

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
# Description

Cascades the in-app forms session-expiry fix from `klaviyo-swift-sdk` 5.4.1 into the React Native SDK for the **2.5.1** patch release. Native pin bump only — no TypeScript or bridge changes.

**This replaces #415.** That PR was merged into the old `rel/2.5.1`, which carried six Dependabot commits we do not want in a patch release. This branch is cut fresh from `a9a68fe` (the 2.5.0 point on `master`) and targets the new `rel/2.5.1-patch` release branch.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [ ] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

**Testing status — please read before approving.** The device smoke test has **not** been run. The repaired behaviour is only observable by expiring a forms session on a device, so green CI does not prove the cascade worked. See the Test Plan.

No new tests were added because no first-party code changed. Android parity already holds: upstream swift PR #715 states the fix brings iOS to parity with `klaviyo-android-sdk`, which is why the Android pin does not move.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

Upstream PR #715 is explicit that its changes are internal to `IAFPresentationManager` with no public API changes, and nothing in this repo's public surface moves.

## Changelog / Code Overview

Two commits, seven files.

| File | Change |
| --- | --- |
| `klaviyo-react-native-sdk.podspec` | `KlaviyoSwift`, `KlaviyoLocation`, `KlaviyoForms` pinned `5.4.0` → `5.4.1` |
| `example/ios/Podfile.lock` | all five Klaviyo pods resolve at `5.4.1` |
| `package.json` | `version` → 2.5.1 |
| `ios/klaviyo-sdk-configuration.plist` | `klaviyo_sdk_version` → 2.5.1 |
| `android/src/main/res/values/strings.xml` | `klaviyo_sdk_version_override` → 2.5.1 |
| `example/android/app/build.gradle` | `versionName` → 2.5.1 |
| `example/ios/.../project.pbxproj` | `MARKETING_VERSION` → 2.5.1 |

### Why no wrapper code changes

The podspec pins exact versions, so the bump must be explicit. Past that, the fix arrives through the pinned pod alone:

- The only session-timeout surface is `sessionTimeoutDuration` (`src/Forms.ts:33`), which both bridges pass straight through to the native `InAppFormsConfig` initializer — `ios/KlaviyoBridge.swift:89-90` and `KlaviyoReactNativeSdkModule.kt:146-149`.
- Upstream PR #715 changes only `IAFPresentationManager` internals and leaves `InAppFormsConfig`'s public shape alone.

### What the upstream fix repairs

When a form session expired, the old path destroyed only the webview. On the rebuilt webview's handshake, `startProfileObservation()`'s idempotency guard saw a still-live observer and short-circuited, so the fresh webview never re-subscribed to the event bus and trigger-based forms silently stopped firing. 5.4.1 adds a scoped `tearDownFormWebView()` that clears the observer and its tasks first, plus two adjacent lifecycle repairs.

### Deliberately unchanged

- `android/gradle.properties` stays at `4.5.1`. The bug was iOS only and `4.5.1` is the newest Android release.
- `yarn.lock` is byte-identical to `a9a68fe`. This branch carries none of the Dependabot updates from #391, #392 or #411; those remain on `master` and are planned for the next minor release.

### One incidental line

`example/ios/Podfile.lock` shows an `RCT-Folly` checksum change with its version unchanged at `2024.11.18.00`. React Native is `0.81.5` in both `example/package.json` and `node_modules`. The previously committed lockfile simply held a stale checksum that any regeneration refreshes.

## Test Plan

**Not yet executed.** Reviewers should treat this as outstanding.

1. Lower `sessionTimeoutDuration` in `example/src/hooks/useForms.ts` from `3600` to about `30`.
2. Run the example app on an iOS simulator and register for in-app forms.
3. Configure a form that triggers on a tracked event.
4. Background the app past the timeout, then foreground it.
5. Fire the trigger event and confirm the form appears.
6. Repeat the background/foreground cycle and confirm the form still appears.
7. Revert the `sessionTimeoutDuration` edit.

Run the same steps once on Android as a regression check — the Android pin does not move, so the result must be unchanged.

Local gates already run on this branch: `tsc` clean, `jest` 79 passed, `eslint` clean, `bob build` wrote `lib/module` and `lib/typescript`.

## Related Issues/Tickets

- MAGE-1181 — this ticket
- MAGE-1180 — parent, cascade to both wrappers
- MAGE-1177 — the origin iOS fix
- MAGE-1183 — 2.5.1 release mechanics
- Upstream: https://github.com/klaviyo/klaviyo-swift-sdk/pull/715
- Replaces #415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the SDK and package version to 2.5.1 across Android, iOS, and the example applications.
  * Updated included iOS SDK components to version 5.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->