### PR TITLE
chore(release): merge rel/2.5.1-patch into master [MAGE-1183]

### DIFF
--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-  <string name="klaviyo_sdk_version_override">2.5.0</string>
+  <string name="klaviyo_sdk_version_override">2.5.1</string>
   <string name="klaviyo_sdk_name_override">react_native</string>
 </resources>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
         // so CI can inject a monotonic value from github.run_number. Local
         // builds default to 1.
         versionCode Integer.parseInt(project.findProperty("releaseVersionCode")?.toString() ?: "1")
-        versionName "2.5.0"
+        versionName "2.5.1"
         manifestPlaceholders = [usesCleartextTraffic: "false"]
     }
     signingConfigs {

--- a/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/KlaviyoReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -649,7 +649,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -691,7 +691,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
@@ -735,7 +735,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.klaviyoreactnativesdkexample.KlaviyoReactNativeSdkExampleExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -63,21 +63,21 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - klaviyo-react-native-sdk (2.5.0):
-    - KlaviyoForms (= 5.4.0)
-    - KlaviyoLocation (= 5.4.0)
-    - KlaviyoSwift (= 5.4.0)
+  - klaviyo-react-native-sdk (2.5.1):
+    - KlaviyoForms (= 5.4.1)
+    - KlaviyoLocation (= 5.4.1)
+    - KlaviyoSwift (= 5.4.1)
     - React-Core
-  - KlaviyoCore (5.4.0):
+  - KlaviyoCore (5.4.1):
     - AnyCodable-FlightSchool
-  - KlaviyoForms (5.4.0):
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoLocation (5.4.0):
-    - KlaviyoSwift (~> 5.4.0)
-  - KlaviyoSwift (5.4.0):
+  - KlaviyoForms (5.4.1):
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoLocation (5.4.1):
+    - KlaviyoSwift (~> 5.4.1)
+  - KlaviyoSwift (5.4.1):
     - AnyCodable-FlightSchool
-    - KlaviyoCore (~> 5.4.0)
-  - KlaviyoSwiftExtension (5.4.0)
+    - KlaviyoCore (~> 5.4.1)
+  - KlaviyoSwiftExtension (5.4.1)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2811,15 +2811,15 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  klaviyo-react-native-sdk: 964b9055637c18a7231e8e73372ebb1cd945deb0
-  KlaviyoCore: 4b87a84a10a44110b4ec73459d91f63941bedb47
-  KlaviyoForms: f0849550a57dcf9b70515bfac6bbce7d12b7515b
-  KlaviyoLocation: bfe9010a9da0c4535943a6ba1ee6a5a571dd790c
-  KlaviyoSwift: 07ddea8bee2a80a5e8e25e23231008eb59f2da71
-  KlaviyoSwiftExtension: deb2f4d76a30b7b13bc592a0ece1a6cb2c1e8422
+  klaviyo-react-native-sdk: b8cfe736e5f8d026890953a3d4800309055dc289
+  KlaviyoCore: 252a62ea36e47109e92bd376b0a1c4026b956e75
+  KlaviyoForms: b9767202597c87c1637969f1070903fd7fecfc7e
+  KlaviyoLocation: d69799af58502deb4ce5ce47fec7b6b7e5791f4f
+  KlaviyoSwift: fabd2b2da05f9e7e32ab0d23b560eb90640196b6
+  KlaviyoSwiftExtension: 2f5b9348e2198af88c6bd5189123865732a0ae7c
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
   RCTRequired: cebcf9442fc296c9b89ac791dfd463021d9f6f23
   RCTTypeSafety: b99aa872829ee18f6e777e0ef55852521c5a6788

--- a/ios/klaviyo-sdk-configuration.plist
+++ b/ios/klaviyo-sdk-configuration.plist
@@ -5,6 +5,6 @@
 	<key>klaviyo_sdk_name</key>
 	<string>react_native</string>
 	<key>klaviyo_sdk_version</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 </dict>
 </plist>

--- a/klaviyo-react-native-sdk.podspec
+++ b/klaviyo-react-native-sdk.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-Core"
-  s.dependency "KlaviyoSwift", "5.4.0"
+  s.dependency "KlaviyoSwift", "5.4.1"
   # Optional location and forms; included by default, set to 'false' to exclude
   if ENV['KLAVIYO_INCLUDE_LOCATION'] != 'false'
-    s.dependency "KlaviyoLocation", "5.4.0"
+    s.dependency "KlaviyoLocation", "5.4.1"
   end
   if ENV['KLAVIYO_INCLUDE_FORMS'] != 'false'
-    s.dependency "KlaviyoForms", "5.4.0"
+    s.dependency "KlaviyoForms", "5.4.1"
   end
 
   s.default_subspecs = :none

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klaviyo-react-native-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Official Klaviyo React Native SDK",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
# Description

Merges the **2.5.1** release branch back into `master`. Replaces #414, whose head branch was the old `rel/2.5.1`; GitHub cannot change a pull request's head branch, so a new PR was required.

## Due Diligence

- [ ] I have tested this on a simulator/emulator or a physical device, on iOS and Android (if applicable).
- [x] I have added sufficient unit/integration tests of my changes.
- [x] I have adjusted or added new test cases to team test docs, if applicable.
- [x] I am confident these changes are implemented with feature parity across iOS and Android (if applicable).

No new code here. Everything was reviewed on #419 before it merged into `rel/2.5.1-patch`. The device smoke test for the forms session-timeout fix remains outstanding — see #419.

## Release/Versioning Considerations

- [x] `Patch` Contains internal changes or backwards-compatible bug fixes.
- [ ] `Minor` Contains changes to the public API.
- [ ] `Major` Contains **breaking** changes.
- [x] This is planned work for an upcoming release.

## Changelog / Code Overview

Carries the 2.5.1 release commits to `master`:

| File | Change |
| --- | --- |
| `klaviyo-react-native-sdk.podspec` | `KlaviyoSwift`, `KlaviyoLocation`, `KlaviyoForms` pinned `5.4.0` → `5.4.1` |
| `example/ios/Podfile.lock` | all five Klaviyo pods resolve at `5.4.1` |
| `package.json` | `version` → 2.5.1 |
| `ios/klaviyo-sdk-configuration.plist` | `klaviyo_sdk_version` → 2.5.1 |
| `android/src/main/res/values/strings.xml` | `klaviyo_sdk_version_override` → 2.5.1 |
| `example/android/app/build.gradle` | `versionName` → 2.5.1 |
| `example/ios/.../project.pbxproj` | `MARKETING_VERSION` → 2.5.1 |

### Why the release branch was re-cut

`rel/2.5.1-patch` starts at `a9a68fe`, the commit where 2.5.0 landed on `master`. The previous `rel/2.5.1` had been cut from the `master` tip and so inherited six Dependabot commits from #391, #392 and #411. A patch release should carry only its own fix, so the branch was re-cut and the work re-applied.

### This does not revert the Dependabot updates

`rel/2.5.1-patch` never touches `yarn.lock`, and the only `package.json` line it changes is `version`. The Dependabot commits changed `yarn.lock` and `resolutions.protobufjs` — different content. Verified with `git merge-tree`, which computes a merge result without writing: merging this branch changes zero files on `master` beyond the release commits listed above, and touches neither `yarn.lock` nor the `resolutions` block.

Those five package updates — `brace-expansion`, `ws`, `protobufjs`, `ip-address`, `js-yaml` — stay on `master` and are planned for the next minor release.

## Test Plan

CI on #419 covered the change set: lint, typecheck, jest, build-library, and both architectures on both platforms.

## Open items, not blockers for this merge

1. **The npm publish for 2.5.1 failed.** The GitHub Release published at 20:33:36Z and `publish-sdk.yml` failed with `npm error 404 Not Found - PUT https://registry.npmjs.org/klaviyo-react-native-sdk`. An E404 on `PUT` during publish is npm's response to an auth failure — the registry returns 404 rather than 403 so it does not disclose whether a package exists. The likely cause is an expired, revoked, or under-scoped `NPM_TOKEN`. npm still serves `2.5.0` as `latest`, so **2.5.1 was never published and the version number is not burned** — a retry will work once the token is fixed.
2. **The device smoke test has not run.** See the Test Plan on #419.
3. **`rel/2.5.1` is orphaned** at `0ad1287`. It could not be force-moved or deleted. Someone with repo admin should remove or re-point it so it is not mistaken for the release branch.

## Related Issues/Tickets

- MAGE-1183 — 2.5.1 release mechanics
- MAGE-1181 — the cascade work, #419
- Replaces #414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the SDK and package version to 2.5.1.
  * Updated the iOS and Android example app versions to 2.5.1.
  * Updated iOS native SDK components to version 5.4.1.
  * Applied the updated versions consistently across supported platform configurations and example projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->